### PR TITLE
suppress debug info generation for C++AMP trampoline functions

### DIFF
--- a/lib/Sema/SemaDeclCXX.cpp
+++ b/lib/Sema/SemaDeclCXX.cpp
@@ -7522,6 +7522,10 @@ void Sema::DeclareAMPSerializer(CXXRecordDecl *ClassDecl, DeclarationName Name) 
                          CXXAMPRestrictCPUAttr(CurrentLocation, Context, 0));
   SerializeFunc->addAttr(::new (Context)
                          AnnotateAttr(CurrentLocation, Context, "serialize", 0));
+
+  // don't generate any debug info
+  SerializeFunc->addAttr(new (Context) NoDebugAttr(CurrentLocation, Context, 0));
+
   ClassDecl->addDecl(SerializeFunc);
   // Now we've obtained a valid Name. Use that to recursively declare
   // __cxxamp_serialize() for member classes. TBD: base classes?
@@ -7662,6 +7666,10 @@ void Sema::DeclareAMPDeserializer(CXXRecordDecl *ClassDecl, AMPDeserializerArgs 
   Constructor->addAttr(::new (Context) CXXAMPRestrictAMPAttr(ClassLoc, Context, 0));
   Constructor->addAttr(::new (Context)
     AnnotateAttr(ClassLoc, Context, "auto_deserialize", 0));
+
+  // don't generate any debug info
+  Constructor->addAttr(new (Context) NoDebugAttr(ClassLoc, Context, 0));
+
   // Introduce this constructor into its scope.
   if (Scope *S = getScopeForContext(ClassDecl))
     PushOnScopeChains(Constructor, S, false);
@@ -11617,6 +11625,10 @@ void Sema::DeclareAMPTrampolineName(CXXRecordDecl *ClassDecl, DeclarationName Na
      Trampoline->addAttr(new (Context) CXXAMPRestrictAMPAttr(CurrentLocation, Context, 0));
   Trampoline->addAttr(new (Context) CXXAMPRestrictCPUAttr(CurrentLocation, Context, 0));
   Trampoline->addAttr(new (Context) AnnotateAttr(CurrentLocation, Context, "__cxxamp_trampoline_name", 0));
+
+  // don't generate any debug info
+  Trampoline->addAttr(new (Context) NoDebugAttr(CurrentLocation, Context, 0));
+
   ClassDecl->addDecl(Trampoline);
   // Generate definition
   MarkFunctionReferenced(CurrentLocation, Trampoline);
@@ -11664,6 +11676,10 @@ void CreateDummyAMPTrampoline(Sema& S, DeclarationName Name, CXXRecordDecl *&Cla
    // Manually add this Attribute on this stage to avoid
    //     ClassDecl->getCXXAMPDeserializationConstructor() == NULL
    Trampoline->addAttr(::new (Context) AnnotateAttr(CurrentLocation, Context, "dummy_deserialize", 0));
+
+   // don't generate any debug info
+   Trampoline->addAttr(new (Context) NoDebugAttr(CurrentLocation, Context, 0));
+
    ClassDecl->addDecl(Trampoline);
 }
 
@@ -11872,6 +11888,10 @@ void Sema::DeclareAMPTrampoline(CXXRecordDecl *ClassDecl,
   // so that parallel_for_each can find it.
   Trampoline->addAttr(::new (Context) CXXAMPRestrictCPUAttr(CurrentLocation, Context, 0));
   Trampoline->addAttr(::new (Context) AnnotateAttr(CurrentLocation, Context, "__cxxamp_trampoline", 0));
+
+  // don't generate any debug info
+  Trampoline->addAttr(new (Context) NoDebugAttr(CurrentLocation, Context, 0));
+
   ClassDecl->addDecl(Trampoline);
   // Generate definition
   MarkFunctionReferenced(CurrentLocation, Trampoline);


### PR DESCRIPTION
this prevents the DWARF DIEs to be genarated for the trampoline, serialization functions