### PR TITLE
SWDEV-107888 – fix invalid GCCInstallation for HCCToolChain

### DIFF
--- a/lib/Driver/ToolChains.cpp
+++ b/lib/Driver/ToolChains.cpp
@@ -5318,7 +5318,10 @@ SanitizerMask PS4CPU::getSupportedSanitizers() const {
 
 HCCToolChain::HCCToolChain(const Driver &D, const llvm::Triple &Triple,
                            const ArgList &Args)
-    : Linux(D, Triple, Args) {}
+    : Linux(D, Triple, Args) {
+  llvm::Triple defaultTriple(llvm::sys::getDefaultTargetTriple());
+  GCCInstallation.init(defaultTriple, Args);
+}
 
 void
 HCCToolChain::addClangTargetOptions(const llvm::opt::ArgList &DriverArgs,


### PR DESCRIPTION
[Root cause] 
GCCInstallation is invalid from the very beginning (HCCToolChain’s ctor), because of amdgcn—amdhsa-hcc triple is used, for which there is no GCC installation. As a result the following system includes are missing in clang’s command line for kernel code compilation (because the function AddClangCXXStdlibIncludeArgs() responsible for adding these includes returns false on checking GCCInstallation):
-I /usr/include/x86_64-linux-gnu
-I /usr/include/x86_64-linux-gnu/c++/4.8
-I /usr/include/c++/4.8

[Fix]
Add explicit GCCInstallation initialization in HCCToolChain’s ctor based on default target triple (the same as for CPU code) instead of amdgcn’s.

[Result]
AddClangCXXStdlibIncludeArgs() started to work correctly based on valid GCCInstallation and the above libstdc++ includes are added to clang’s command line for kernel code compilation; -triple amdgcn--amdhsa-hcc remained unchanged.