### PR TITLE
Enable C++14 and C++1z for C++AMP and HC code

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,16 @@ How to Build It
 This is how I build it now. The commands assumes:
 - ROCm stack is already installed
 - ROCm-Device-Libs is built, and installed at ~/hcc/ROCm-Device-Libs/build/dist
-
-```
+- N is the number of threads available for make
+```bash
 git clone --recursive -b clang_tot_upgrade git@github.com:RadeonOpenCompute/hcc.git hcc_upstream
 mkdir build_upstream
 cd build_upstream
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
-    -DHSA_AMDGPU_GPU_TARGET=AMD:AMDGPU:8:0:3 \
+    -DHSA_AMDGPU_GPU_TARGET=gfx803 \
     -DROCM_DEVICE_LIB_DIR=~/hcc/ROCm-Device-Libs/build/dist/lib \
     ../hcc_upstream
-make -j56 world
-make -j56
+make -jN world
+make -jN
 ```

--- a/include/clang/Frontend/LangStandards.def
+++ b/include/clang/Frontend/LangStandards.def
@@ -166,7 +166,8 @@ LANGSTANDARD(cuda, "cuda",
 // C++AMP
 LANGSTANDARD(cxxamp, "c++amp",
              "ECMA C++AMP Standard",
-             LineComment | CPlusPlus | CPlusPlus11 | CPlusPlusAMP | Digraphs)
+             LineComment | CPlusPlus | CPlusPlus11 | CPlusPlus14 | CPlusPlus1z |
+             CPlusPlusAMP | Digraphs | HexFloat)
 
 #undef LANGSTANDARD
 #undef LANGSTANDARD_ALIAS

--- a/lib/Driver/Tools.cpp
+++ b/lib/Driver/Tools.cpp
@@ -48,6 +48,8 @@
 #include <unistd.h> // For getuid().
 #endif
 
+#include <regex>
+
 using namespace clang::driver;
 using namespace clang::driver::tools;
 using namespace clang;
@@ -4458,7 +4460,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (ReciprocalMath)
     CmdArgs.push_back("-freciprocal-math");
 
-  if (!TrappingMath) 
+  if (!TrappingMath)
     CmdArgs.push_back("-fno-trapping-math");
 
   if (Args.hasArg(options::OPT_fdenormal_fp_math_EQ))
@@ -4705,6 +4707,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
 
   Args.ClaimAllArgs(options::OPT_g_Group);
   Arg *SplitDwarfArg = Args.getLastArg(options::OPT_gsplit_dwarf);
+
+  // disable debug output for HCC kernel path
+  if (!IsHCCKernelPath) {
+
   if (Arg *A = Args.getLastArg(options::OPT_g_Group)) {
     // If the last option explicitly specified a debug-info level, use it.
     if (A->getOption().matches(options::OPT_gN_Group)) {
@@ -4822,6 +4828,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-backend-option");
     CmdArgs.push_back("-generate-type-units");
   }
+
+  } // if (!IsHCCKernelPath)
 
   // CloudABI and WebAssembly use -ffunction-sections and -fdata-sections by
   // default.
@@ -5585,7 +5593,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back(Args.MakeArgString(
           std::string("-fprebuilt-module-path=") + A->getValue()));
   }
-      
+
   // -fmodule-name specifies the module that is currently being built (or
   // used for header checking by -fmodule-maps).
   Args.AddLastArg(CmdArgs, options::OPT_fmodule_name_EQ);
@@ -6098,7 +6106,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-fno-gnu-inline-asm");
 
   // Turn off vectorization support for GPU kernels for now
-  if (!IsCXXAMPBackendJobAction(&JA) && !IsCXXAMPCPUBackendJobAction(&JA))  {
+  if (!IsHCCKernelPath) {
 
   // Enable vectorization per default according to the optimization level
   // selected. For optimization levels that want vectorization we use the alias
@@ -9936,60 +9944,24 @@ void gnutools::Linker::ConstructLinkerJob(Compilation &C, const JobAction &JA,
   }
 }
 
-void gnutools::Linker::ConstructJob(Compilation &C, const JobAction &JA,
+void gnutools::Linker::ConstructJob(Compilation &C,
+                                    const JobAction &JA,
                                     const InputInfo &Output,
                                     const InputInfoList &Inputs,
                                     const ArgList &Args,
                                     const char *LinkingOutput) const {
-  ArgStringList CmdArgs;
-  ConstructLinkerJob(C, JA, Output, Inputs, Args, LinkingOutput, CmdArgs);
-
-  // UPGRADE_TBD: remove this once we hace HCCToolChain
   if (Driver::IsCXXAMP(C.getArgs())) {
-
-    // FIXME: logic here should be placed in HCC:CXXAMPLink::ConstructJob()
-    // add verbose flag to linker script if clang++ is invoked with --verbose flag
-    if (Args.hasArg(options::OPT_v))
-      CmdArgs.push_back("--verbose");
-
-    // specify AMDGPU target
-    if (Args.hasArg(options::OPT_amdgpu_target_EQ)) {
-      std::vector<std::string> AMDGPUTargetVector = Args.getAllArgValues(options::OPT_amdgpu_target_EQ);
-
-      for (auto& AMDGPUTarget : AMDGPUTargetVector) {
-        // check if valid AMDGPU target is specified
-        bool FoundAMDGPUTarget = true;
-
-        SmallString<32> LinkerArgString("--amdgpu-target=");
-
-        // map ISA version string to GPU family
-        if (!AMDGPUTarget.compare("AMD:AMDGPU:7:0:1")) {
-          LinkerArgString.append("hawaii");
-        } else if (!AMDGPUTarget.compare("AMD:AMDGPU:8:0:1")) {
-          LinkerArgString.append("carrizo");
-        } else if (!AMDGPUTarget.compare("AMD:AMDGPU:8:0:3")) {
-          LinkerArgString.append("fiji");
-        } else if (!AMDGPUTarget.compare("fiji") ||
-                   !AMDGPUTarget.compare("carrizo") ||
-                   !AMDGPUTarget.compare("hawaii")) {
-          // directly use GPU family
-          LinkerArgString.append(AMDGPUTarget);
-        } else {
-          FoundAMDGPUTarget = false;
-        }
-
-        if (FoundAMDGPUTarget) {
-          CmdArgs.push_back(Args.MakeArgString(LinkerArgString));
-        } else {
-          // ignore invalid AMDGPU target
-          C.getDriver().Diag(diag::warn_amdgpu_target_invalid) << AMDGPUTarget;
-        }
-      }
-    }
-
-    const char *Exec = Args.MakeArgString(getToolChain().GetProgramPath("clamp-link"));
-    C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, Inputs));
+    HCC::CXXAMPLink{getToolChain()}.ConstructJob(C,
+                                                 JA,
+                                                 Output,
+                                                 Inputs,
+                                                 Args,
+                                                 LinkingOutput);
   } else {
+    ArgStringList CmdArgs;
+
+    ConstructLinkerJob(C, JA, Output, Inputs, Args, LinkingOutput, CmdArgs);
+
     const char *Exec = Args.MakeArgString(getToolChain().GetLinkerPath());
     C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, Inputs));
   }
@@ -11989,11 +11961,12 @@ void HCC::CXXAMPAssemble::ConstructJob(Compilation &C, const JobAction &JA,
   C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, Inputs));
 }
 
-void HCC::CXXAMPLink::ConstructJob(Compilation &C, const JobAction &JA,
-                                        const InputInfo &Output,
-                                        const InputInfoList &Inputs,
-                                        const ArgList &Args,
-                                        const char *LinkingOutput) const {
+void HCC::CXXAMPLink::ConstructJob(Compilation &C,
+                                   const JobAction &JA,
+                                   const InputInfo &Output,
+                                   const InputInfoList &Inputs,
+                                   const ArgList &Args,
+                                   const char *LinkingOutput) const {
   ArgStringList CmdArgs;
 
   // add verbose flag to linker script if clang++ is invoked with --verbose flag
@@ -12002,34 +11975,26 @@ void HCC::CXXAMPLink::ConstructJob(Compilation &C, const JobAction &JA,
 
   // specify AMDGPU target
   if (Args.hasArg(options::OPT_amdgpu_target_EQ)) {
-    std::vector<std::string> AMDGPUTargetVector = Args.getAllArgValues(options::OPT_amdgpu_target_EQ);
+    auto AMDGPUTargetVector = Args.getAllArgValues(options::OPT_amdgpu_target_EQ);
 
-    for (auto& AMDGPUTarget : AMDGPUTargetVector) {
-      // check if valid AMDGPU target is specified
-      bool FoundAMDGPUTarget = true;
+    for (auto&& AMDGPUTarget : AMDGPUTargetVector) {
+      // TODO: the known GFXip list should probably reside in a constant
+      //       global variable so as to allow easy extension in the future.
+      static constexpr const char prefix[] = "--amdgpu-target=";
+      static constexpr unsigned int discard_sz = 3u;
+      static const std::regex gfx_ip{"gfx(701|801|802|803)"};
 
-      SmallString<32> LinkerArgString("--amdgpu-target=");
-
-      // map ISA version string to GPU family
-      if (!AMDGPUTarget.compare("AMD:AMDGPU:7:0:1")) {
-        LinkerArgString.append("hawaii");
-      } else if (!AMDGPUTarget.compare("AMD:AMDGPU:8:0:1")) {
-        LinkerArgString.append("carrizo");
-      } else if (!AMDGPUTarget.compare("AMD:AMDGPU:8:0:3")) {
-        LinkerArgString.append("fiji");
-      } else if (!AMDGPUTarget.compare("fiji") ||
-                 !AMDGPUTarget.compare("carrizo") ||
-                 !AMDGPUTarget.compare("hawaii")) {
-        // directly use GPU family
-        LinkerArgString.append(AMDGPUTarget);
-      } else {
-        FoundAMDGPUTarget = false;
+      if (std::regex_search(AMDGPUTarget, gfx_ip)) {
+        std::string t{prefix};
+        switch (std::atoi(AMDGPUTarget.data() + discard_sz)) {
+        case 701: t += "hawaii";  break;
+        case 801: t += "carrizo"; break;
+        case 802: t += "tonga";   break;
+        case 803: t += "fiji";    break;
+        }
+        CmdArgs.push_back(Args.MakeArgString(t));
       }
-
-      if (FoundAMDGPUTarget) {
-        CmdArgs.push_back(Args.MakeArgString(LinkerArgString));
-      } else {
-        // ignore invalid AMDGPU target
+      else {
         C.getDriver().Diag(diag::warn_amdgpu_target_invalid) << AMDGPUTarget;
       }
     }


### PR DESCRIPTION
This enables C++14 and C++1z(aka 17) support for code compiled with either the -std=c++amp or the -hc flag. Note that there are still some rough edges (e.g. passing generic lambdas as the Callable argument for a p_f_e), which will be smoothed out. Furthermore, in the future we might consider refactoring this part so as to make C++AMP/HCC enablement orthogonal to the particular version of the standard. Unit test pass-rate is unaffected, but this is more of an illustration of the (temporary) lack of coverage on our part.