### PR TITLE
Enable short-form GFX_ip names (v2).

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ToT HCC Clang
 =============
 
-This repository ToT HCC Clang which is synchronized with upstream Clang.
+This repository hosts ToT HCC Clang which is synchronized with upstream Clang.
 
 Branches
 ========
@@ -22,16 +22,17 @@ How to Build It
 This is how I build it now. The commands assumes:
 - ROCm stack is already installed
 - ROCm-Device-Libs is built, and installed at ~/hcc/ROCm-Device-Libs/build/dist
+- N is the number of threads available for make
 
-```
+```bash
 git clone --recursive -b clang_tot_upgrade git@github.com:RadeonOpenCompute/hcc.git hcc_upstream
 mkdir build_upstream
 cd build_upstream
 cmake \
     -DCMAKE_BUILD_TYPE=Release \
-    -DHSA_AMDGPU_GPU_TARGET=AMD:AMDGPU:8:0:3 \
+    -DHSA_AMDGPU_GPU_TARGET=gfx803 \
     -DROCM_DEVICE_LIB_DIR=~/hcc/ROCm-Device-Libs/build/dist/lib \
     ../hcc_upstream
-make -j56 world
-make -j56
+make -jN world
+make -jN
 ```

--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -377,7 +377,7 @@ def cxxamp_kernel_mode : Flag<["-"], "gpu">, Flags<[DriverOption]>,Group<cxxamp_
 def cxxamp_cpu_mode : Flag<["-"], "cpu">, Flags<[DriverOption]>,Group<cxxamp_Group>,
   HelpText<"C++AMP only.  This option allows the compiler to emit CPU kernel-specific artifacts"> ;
 def amdgpu_target_EQ : Joined<["-", "--"], "amdgpu-target=">, Flags<[DriverOption]>,
-  HelpText<"Specify AMDGPU ISA version (ex: AMD:AMDGPU:8:0:3). Could be specified only once.">;
+  HelpText<"Specify AMDGPU ISA version (ex: gfx803). Could be specified only once.">;
 def cl_opt_disable : Flag<["-"], "cl-opt-disable">, Group<opencl_Group>, Flags<[CC1Option]>,
   HelpText<"OpenCL only. This option disables all optimizations. By default optimizations are enabled.">;
 def cl_strict_aliasing : Flag<["-"], "cl-strict-aliasing">, Group<opencl_Group>, Flags<[CC1Option]>,


### PR DESCRIPTION
This implements the change required by the adoption of short-form GFX_ip family names, in the custom Linker Driver bits used by HCC. It also seizes the opportunity to refactor duplicate functionality into a single function i.e. HCC::CXXAMPLink::ConstructJob. Since it employs C++11 regex support, it generates a soft dependency on libstdc++, which must be at least version 4.9. If this is considered terribly onerous, and if the support that was shipped in 4.8 proves inadequate, I can easily refactor it into a form that does not use regex. Jack's suggestion about supporting long-form through the transition phase has been implemented. Thank you.