### PR TITLE
set hcc driver to g++ mode

### DIFF
--- a/lib/Driver/ToolChain.cpp
+++ b/lib/Driver/ToolChain.cpp
@@ -112,6 +112,7 @@ const DriverSuffix *FindDriverSuffix(StringRef ProgName) {
       {"clang-g++", "--driver-mode=g++"},
       {"clang-gcc", nullptr},
       {"clang-cl", "--driver-mode=cl"},
+      {"hcc", "--driver-mode=g++"},
       {"cc", nullptr},
       {"cpp", "--driver-mode=cpp"},
       {"cl", "--driver-mode=cl"},


### PR DESCRIPTION
this configures hcc driver to invoke the clang frontend the same way as clang++ does, which includes linking against libstdc++ for example