### PR TITLE
Better support for the -E option in hcc

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -1595,12 +1595,14 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
           switch (FinalPhase) {
             // -E
             case phases::Preprocess:
-              if (Args.hasArg(options::OPT_cxxamp_kernel_mode)) {
-                Inputs.push_back(std::make_pair(types::TY_CXX_AMP, A));
-              } else if (Args.hasArg(options::OPT_cxxamp_cpu_mode)) {
+              if (Args.hasArg(options::OPT_cxxamp_cpu_mode))
                   Inputs.push_back(std::make_pair(types::TY_CXX_AMP_CPU, A));
+              if(Args.hasArg(options::OPT_hc_mode)) {
+                Inputs.push_back(std::make_pair(types::TY_HC_HOST, A));
+                Inputs.push_back(std::make_pair(types::TY_HC_KERNEL, A));
               } else {
                 Inputs.push_back(std::make_pair(Ty, A));
+                Inputs.push_back(std::make_pair(types::TY_CXX_AMP, A));
               }
             break;
 


### PR DESCRIPTION
- currently the -E option doesn't work with the -hc option.
- teach -E to generate 2 output files, one for the host and another for the GPU path (with a .gpu.i extension)
