### PR TITLE
allow inline asm on GPU when the hc option is in effect

### DIFF
--- a/lib/Parse/ParseStmt.cpp
+++ b/lib/Parse/ParseStmt.cpp
@@ -277,8 +277,11 @@ Retry:
     break;
 
   case tok::kw_asm: {
-    // C++ AMP-specific, reject if we are in an AMP-restricted function
-    if (getLangOpts().CPlusPlusAMP && getLangOpts().DevicePath) {
+
+    // C++ AMP-specific, reject if we are in an AMP-restricted function 
+    if (getLangOpts().CPlusPlusAMP &&
+        !getLangOpts().HSAExtension &&
+        getLangOpts().DevicePath) {
       if (IsInAMPFunction(getCurScope())) {
         Diag(Tok, diag::err_amp_illegal_keyword_asm);
       }


### PR DESCRIPTION
Allow inline asm on GPU path when HSA extension is enabled

NOTE: inline asm only works on promote-free branch.  It fails on clang_tot_upgrade due to issues in promotion pass.