### PR TITLE
Use dyn_cast to return null if casting fails

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2863,7 +2863,7 @@ void Driver::BuildJobs(Compilation &C) const {
         LinkingOutput = getDefaultImageName();
     }
 
-    JobAction *JA = cast<JobAction>(A);
+    JobAction *JA = dyn_cast<JobAction>(A);
     // UPGRADE_TBD: FIXME This is hack. Need to find a cleaner way
     // The line is added so clang -emit-llvm would pick correct toolchain for HCC inputs
     if (JA && IsCXXAMPBackendJobAction(JA)) {


### PR DESCRIPTION
Need to check returned pointer. So use dyn_cast instead of checked cast which won't return anything if a casting fails.