### PR TITLE
For OpenMP dialect, pointer type of kernel arg might not be Cannonica…

### DIFF
--- a/lib/CodeGen/CGCall.cpp
+++ b/lib/CodeGen/CGCall.cpp
@@ -737,9 +737,6 @@ CodeGenTypes::arrangeLLVMFunctionInfo(CanQualType resultType,
                                       RequiredArgs required) {
   if (CGM.getTriple().getArch()==llvm::Triple::amdgcn &&
      CGM.getLangOpts().OpenMPIsDevice) {
-    assert(std::all_of(argTypes.begin(), argTypes.end(),
-                     [](CanQualType T) {
-      return QualType(T)->isAnyPointerType() || T.isCanonicalAsParam(); }));
   } else
   assert(std::all_of(argTypes.begin(), argTypes.end(),
                      [](CanQualType T) { return T.isCanonicalAsParam(); }));

--- a/lib/CodeGen/CGCall.cpp
+++ b/lib/CodeGen/CGCall.cpp
@@ -735,6 +735,12 @@ CodeGenTypes::arrangeLLVMFunctionInfo(CanQualType resultType,
                                       FunctionType::ExtInfo info,
                      ArrayRef<FunctionProtoType::ExtParameterInfo> paramInfos,
                                       RequiredArgs required) {
+  if (CGM.getTriple().getArch()==llvm::Triple::amdgcn &&
+     CGM.getLangOpts().OpenMPIsDevice) {
+    assert(std::all_of(argTypes.begin(), argTypes.end(),
+                     [](CanQualType T) {
+      return QualType(T)->isAnyPointerType() || T.isCanonicalAsParam(); }));
+  } else
   assert(std::all_of(argTypes.begin(), argTypes.end(),
                      [](CanQualType T) { return T.isCanonicalAsParam(); }));
 


### PR DESCRIPTION
…l. Relax the rule