### PR TITLE
whitelist kokkos

### DIFF
--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -1991,6 +1991,7 @@ static bool isWhiteListForHCC(CodeGenModule &CGM, GlobalDecl GD) {
         MangledName.find("4move") != StringRef::npos ||
         MangledName.find("16grid_launch_parm10KernelArgsIT2_EENKUlvE_clEv") != StringRef::npos ||
         MangledName.find("St12memory_order") != StringRef::npos ||
+        MangledName.find("Kokkos4Impl") != StringRef::npos ||
         MangledName.find("Eigen8internal") != StringRef::npos) {
       return true;
     }


### PR DESCRIPTION
Device path workaround for codegen issues with Kokkos functions not explicitly marked with [[hc]] 