### PR TITLE
CodeGen: do not insert addr space casts for function parameter variables

### DIFF
--- a/lib/CodeGen/CGDecl.cpp
+++ b/lib/CodeGen/CGDecl.cpp
@@ -1860,7 +1860,7 @@ void CodeGenFunction::EmitParmDecl(const VarDecl &D, ParamValue Arg,
   } else {
     // Otherwise, create a temporary to hold the value.
     DeclPtr = CreateMemTemp(Ty, getContext().getDeclAlign(&D),
-                            D.getName() + ".addr");
+                            D.getName() + ".addr", false);
     DoStore = true;
   }
 


### PR DESCRIPTION
This patch gets rid of most of the soft hangs in unit tests.
It makes the IR much cleaner due to avoid redundant address space casts for function parameter variables, which may help improve performance.