### PR TITLE
[AMDGPU] Temporarily change constant address space from 4 to 2 for th…

### DIFF
--- a/lib/Basic/Targets.cpp
+++ b/lib/Basic/Targets.cpp
@@ -2053,11 +2053,11 @@ static const LangAS::Map AMDGPUGenericIsZeroMap = {
     0,  // Default
     1,  // opencl_global
     3,  // opencl_local
-    4,  // opencl_constant
+    2,  // opencl_constant
     5,  // opencl_private
     0,  // opencl_generic
     1,  // cuda_device
-    4,  // cuda_constant
+    2,  // cuda_constant
     3,  // cuda_shared
     3,  // hcc_tilestatic
     0,  // hcc_generic
@@ -2077,7 +2077,7 @@ static const char *const DataLayoutStringSIPrivateIsZero =
   "-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64";
 
 static const char *const DataLayoutStringSIGenericIsZero =
-  "e-p:64:64-p1:64:64-p2:64:64-p3:32:32-p4:64:64-p5:32:32"
+  "e-p:64:64-p1:64:64-p2:64:64-p3:32:32-p4:32:32-p5:32:32"
   "-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128"
   "-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-A5";
 
@@ -2092,7 +2092,7 @@ class AMDGPUTargetInfo final : public TargetInfo {
         Generic   = 0;
         Global    = 1;
         Local     = 3;
-        Constant  = 4;
+        Constant  = 2;
         Private   = 5;
       } else {
         Generic   = 4;

--- a/test/CodeGenOpenCL/address-space-constant-initializers.cl
+++ b/test/CodeGenOpenCL/address-space-constant-initializers.cl
@@ -1,4 +1,6 @@
 // RUN: %clang_cc1 %s -ffake-address-space-map -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -triple amdgcn-amd-amdhsa-opencl -emit-llvm -o - | FileCheck %s
+// RUN: %clang_cc1 %s -triple amdgcn-amd-amdhsa-amdgizcl -emit-llvm -o - | FileCheck %s
 
 typedef struct {
     int i;


### PR DESCRIPTION
…e new address space mapping

Change constant address space from 4 to 2 for the new address space mapping in Clang.

Differential Revision: https://reviews.llvm.org/D31771

git-svn-id: https://llvm.org/svn/llvm-project/cfe/trunk@299691 91177308-0d34-0410-b5e6-96231b3b80d8