### PR TITLE
C++14 features support for -std=c++amp

### DIFF
--- a/include/clang/Frontend/LangStandards.def
+++ b/include/clang/Frontend/LangStandards.def
@@ -166,7 +166,7 @@ LANGSTANDARD(cuda, "cuda",
 // C++AMP
 LANGSTANDARD(cxxamp, "c++amp",
              "ECMA C++AMP Standard",
-             LineComment | CPlusPlus | CPlusPlus11 | CPlusPlusAMP | Digraphs)
+             LineComment | CPlusPlus | CPlusPlus11 | CPlusPlus14 | CPlusPlusAMP | Digraphs)
 
 #undef LANGSTANDARD
 #undef LANGSTANDARD_ALIAS


### PR DESCRIPTION
Enable C++14 support for -std=c++amp

C++14 support is required for HCC on Windows