### PR TITLE
Pass hcc-extra-libs flag to clamp-link

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -483,6 +483,8 @@ def cxxamp_cpu_mode : Flag<["-"], "cpu">, Flags<[DriverOption]>,Group<cxxamp_Gro
   HelpText<"C++AMP only.  This option allows the compiler to emit CPU kernel-specific artifacts"> ;
 def amdgpu_target_EQ : Joined<["-", "--"], "amdgpu-target=">, Flags<[DriverOption]>,
   HelpText<"Specify AMDGPU ISA version (ex: gfx803). Could be specified only once.">;
+def hcc_extra_libs_EQ : Joined<["-", "--"], "hcc-extra-libs=">, Flags<[DriverOption]>,
+  HelpText<"Specify hcc extra libraries to be linked in.">;
 def cl_opt_disable : Flag<["-"], "cl-opt-disable">, Group<opencl_Group>, Flags<[CC1Option]>,
   HelpText<"OpenCL only. This option disables all optimizations. By default optimizations are enabled.">;
 def cl_strict_aliasing : Flag<["-"], "cl-strict-aliasing">, Group<opencl_Group>, Flags<[CC1Option]>,

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -204,9 +204,18 @@ void HCC::CXXAMPLink::ConstructJob(Compilation &C,
   // pass inputs to gnu ld for initial processing
   Linker::ConstructLinkerJob(C, JA, Output, Inputs, Args, LinkingOutput, CmdArgs);
 
+  auto ClampArgs = CmdArgs;
+  if (Args.hasArg(options::OPT_hcc_extra_libs_EQ)) {
+    auto HccExtraLibs = Args.getAllArgValues(options::OPT_hcc_extra_libs_EQ);
+    std::string prefix{"--hcc-extra-libs="};
+    for(auto&& Lib:HccExtraLibs) {
+      ClampArgs.push_back(Args.MakeArgString(prefix + Lib));
+    }
+  }
+
   const char *Exec = Args.MakeArgString(getToolChain().GetProgramPath("clamp-link"));
 
-  C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, CmdArgs, Inputs));
+  C.addCommand(llvm::make_unique<Command>(JA, *this, Exec, ClampArgs, Inputs));
 }
 
 /// HCC toolchain.


### PR DESCRIPTION
This is so `clamp-link` can add extra libraries without needing an environment variable.