### PR TITLE
Patches to enable TensorFlow

### DIFF
--- a/lib/CodeGen/CGExprComplex.cpp
+++ b/lib/CodeGen/CGExprComplex.cpp
@@ -649,7 +649,8 @@ ComplexPairTy ComplexExprEmitter::EmitBinMul(const BinOpInfo &Op) {
   Value *ResR, *ResI;
   llvm::MDBuilder MDHelper(CGF.getLLVMContext());
 
-  if (Op.LHS.first->getType()->isFloatingPointTy()) {
+  // XXX disable complex number builtin for now
+  if (false && Op.LHS.first->getType()->isFloatingPointTy()) {
     // The general formulation is:
     // (a + ib) * (c + id) = (a * c - b * d) + i(a * d + b * c)
     //
@@ -752,7 +753,8 @@ ComplexPairTy ComplexExprEmitter::EmitBinDiv(const BinOpInfo &Op) {
 
 
   llvm::Value *DSTr, *DSTi;
-  if (LHSr->getType()->isFloatingPointTy()) {
+  // XXX disable complex number builtin for now
+  if (false && LHSr->getType()->isFloatingPointTy()) {
     // If we have a complex operand on the RHS, we delegate to a libcall to
     // handle all of the complexities and minimize underflow/overflow cases.
     //

--- a/lib/CodeGen/CGExprComplex.cpp
+++ b/lib/CodeGen/CGExprComplex.cpp
@@ -649,8 +649,8 @@ ComplexPairTy ComplexExprEmitter::EmitBinMul(const BinOpInfo &Op) {
   Value *ResR, *ResI;
   llvm::MDBuilder MDHelper(CGF.getLLVMContext());
 
-  // XXX disable complex number builtin for now
-  if (false && Op.LHS.first->getType()->isFloatingPointTy()) {
+  // XXX disable complex number builtin for kernel compilation path for now
+  if (!CGF.CGM.getLangOpts().DevicePath && Op.LHS.first->getType()->isFloatingPointTy()) {
     // The general formulation is:
     // (a + ib) * (c + id) = (a * c - b * d) + i(a * d + b * c)
     //
@@ -753,8 +753,8 @@ ComplexPairTy ComplexExprEmitter::EmitBinDiv(const BinOpInfo &Op) {
 
 
   llvm::Value *DSTr, *DSTi;
-  // XXX disable complex number builtin for now
-  if (false && LHSr->getType()->isFloatingPointTy()) {
+  // XXX disable complex number builtin for kernel compilation path for now
+  if (!CGF.CGM.getLangOpts().DevicePath && LHSr->getType()->isFloatingPointTy()) {
     // If we have a complex operand on the RHS, we delegate to a libcall to
     // handle all of the complexities and minimize underflow/overflow cases.
     //

--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -2027,6 +2027,8 @@ static bool isWhiteListForHCC(CodeGenModule &CGM, GlobalDecl GD) {
   // C++11 functional operators are allowed to pass
   // C++11 swap functions are allowed to pass
   // C++11 numeric limits are allowed to pass
+  // C++11 pair are allowed to pass
+  // C++11 complex are allowed to pass
   // PSTL operators are allowed to pass
   const CXXMethodDecl* MethodD = dyn_cast<CXXMethodDecl>(D);
   if (MethodD) {
@@ -2038,6 +2040,8 @@ static bool isWhiteListForHCC(CodeGenModule &CGM, GlobalDecl GD) {
         ClassName.find("unique_ptr") != StringRef::npos ||
         ClassName.find("compressed_pair") != StringRef::npos ||
         ClassName.find("numeric_limits") != StringRef::npos ||
+        ClassName.find("pair") != StringRef::npos ||
+        ClassName.find("complex") != StringRef::npos ||
         MangledName.find("experimental8parallel") != StringRef::npos) {
       return true;
     }
@@ -2045,6 +2049,8 @@ static bool isWhiteListForHCC(CodeGenModule &CGM, GlobalDecl GD) {
 
   // C++11 swap/move functions are allowed to pass
   // C++11 memory_order modifiers are allowed to pass
+  // C++11 complex operators are allowed to pass
+  // certain C++11 math functions are allowed to pass
   // Eigen internal functions are allowed to pass
   const FunctionDecl* FuncD = dyn_cast<FunctionDecl>(D);
   if (FuncD) {
@@ -2054,6 +2060,8 @@ static bool isWhiteListForHCC(CodeGenModule &CGM, GlobalDecl GD) {
         MangledName.find("St12memory_order") != StringRef::npos ||
         MangledName.find("Kokkos4Impl") != StringRef::npos ||
         MangledName.find("St16initializer_list") != StringRef::npos ||
+        MangledName.find("St7complex") != StringRef::npos ||
+        MangledName.find("5roundf") != StringRef::npos ||
         MangledName.find("Eigen8internal") != StringRef::npos) {
       return true;
     }


### PR DESCRIPTION
Two patches to HCC Clang frontend to enable TensorFlow. Both changes are only temporary and should have better long-term approach devised.

- add more functions into white list
- temporary disable complex number builtins be emitted in the frontend.