### PR TITLE
On rhel7 or centos7, add -lstdc++ to the linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,11 @@ endif()
 
 add_definitions( -D_GNU_SOURCE )
 add_definitions(-DHCC_AMDGPU_TARGET="${AMDGPU_TARGET}")
+if (HCC_TOOLCHAIN_RHEL)
+ add_definitions(-DHCC_TOOLCHAIN_RHEL=true)
+else()
+ add_definitions(-DHCC_TOOLCHAIN_RHEL=false)
+endif()
 
 option(CLANG_BUILD_TOOLS
   "Build the Clang tools. If OFF, just generate build targets." ON)

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -281,6 +281,9 @@ void HCC::CXXAMPLink::ConstructJob(
     // add verbose flag to linker script if clang++ is invoked with --verbose flag
     if (Args.hasArg(options::OPT_v)) CmdArgs.push_back("--verbose");
 
+    // Reverse translate the -lstdc++ option
+    if (Args.hasArg(options::OPT_Z_reserved_lib_stdcxx)) CmdArgs.push_back("-lstdc++");
+
     // specify AMDGPU target
     constexpr const char auto_tgt[] = "auto";
 

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -268,6 +268,10 @@ namespace
     }
 }
 
+#ifndef HCC_TOOLCHAIN_RHEL
+  #define HCC_TOOLCHAIN_RHEL false
+#endif
+
 void HCC::CXXAMPLink::ConstructJob(
     Compilation &C,
     const JobAction &JA,
@@ -282,7 +286,11 @@ void HCC::CXXAMPLink::ConstructJob(
     if (Args.hasArg(options::OPT_v)) CmdArgs.push_back("--verbose");
 
     // Reverse translate the -lstdc++ option
-    if (Args.hasArg(options::OPT_Z_reserved_lib_stdcxx)) CmdArgs.push_back("-lstdc++");
+    // Or add -lstdc++ when running on RHEL 7 or CentOS 7
+    if (Args.hasArg(options::OPT_Z_reserved_lib_stdcxx) ||
+        HCC_TOOLCHAIN_RHEL) {
+        CmdArgs.push_back("-lstdc++");
+    }
 
     // specify AMDGPU target
     constexpr const char auto_tgt[] = "auto";


### PR DESCRIPTION
On RHEL7 or CentOS7, use libc++ from the distro's rpm for C++ runtime but still link to libstdc++ to satisfy a dependency libc++