### PR TITLE
[HCC] Fix address space of tile_static variable.

### DIFF
--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -2753,6 +2753,10 @@ unsigned CodeGenModule::GetGlobalVarAddressSpace(const VarDecl *D) {
       return LangAS::cuda_device;
   }
 
+  if (LangOpts.CPlusPlusAMP && LangOpts.DevicePath &&
+      D && D->hasAttr<HCCTileStaticAttr>())
+    return LangAS::hcc_tilestatic;
+
   return getTargetCodeGenInfo().getGlobalVarAddressSpace(*this, D);
 }
 


### PR DESCRIPTION
This fixes the regressions caused by merge_20170725.