### PR TITLE
AMDGPUABI workaround for grid launch

### DIFF
--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -7523,7 +7523,8 @@ ABIArgInfo AMDGPUABIInfo::classifyArgumentType(QualType Ty,
 
   Ty = useFirstFieldIfTransparentUnion(Ty);
 
-  if (isAggregateTypeForABI(Ty)) {
+  if (isAggregateTypeForABI(Ty)
+      && !getContext().getLangOpts().CPlusPlusAMP) {
     // Records with non-trivial destructors/copy-constructors should not be
     // passed by value.
     if (auto RAA = getRecordArgABI(Ty, getCXXABI()))


### PR DESCRIPTION
"AMDGPU: Use direct struct returns and arguments"
https://github.com/RadeonOpenCompute/clang/commit/f535ad0f83b2f90343cafbf8f929d6c956747263

changes how structs are passed between functions
and that seems to confuse HCC's wrapper gen for
grid launch and hangs the compiler.  Disable
the ABI when compiling in HCC mode for now as
workaround.