### PR TITLE
Integrate hcc-config as part of the driver

### DIFF
--- a/lib/Driver/ToolChains/Gnu.cpp
+++ b/lib/Driver/ToolChains/Gnu.cpp
@@ -29,6 +29,8 @@
 #include "llvm/Support/TargetParser.h"
 #include <system_error>
 
+#include "hcc_config.hxx"
+
 using namespace clang::driver;
 using namespace clang::driver::toolchains;
 using namespace clang;
@@ -2387,4 +2389,30 @@ void Generic_ELF::addClangTargetOptions(const ArgList &DriverArgs,
   if (DriverArgs.hasFlag(options::OPT_fuse_init_array,
                          options::OPT_fno_use_init_array, UseInitArrayDefault))
     CC1Args.push_back("-fuse-init-array");
+
+  if (getenv("HCC_BUILD")) {
+    CC1Args.push_back("-I" CMAKE_BUILD_INC_DIR);
+  }
+  else {
+    std::string path_hcc_include;
+
+    if (const char *p = getenv("HCC_HOME")) {
+      path_hcc_include = std::string(p) + std::string("/include");
+    }
+    else {
+      CC1Args.push_back("-I" CMAKE_ROCM_ROOT "/include");
+      path_hcc_include = getDriver().Dir + "/../../include";
+    }
+
+    HCCIncludePath = "-I" + path_hcc_include;
+    CC1Args.push_back(HCCIncludePath.c_str());
+  }
+
+  if (getenv("HCC_GTEST") && getenv("HCC_BUILD")) {
+    CC1Args.push_back("-I" CMAKE_GTEST_INC_DIR);
+  }
+
+  #ifdef CODEXL_ACTIVITY_LOGGER_ENABLED
+    CC1Args.push_back("-I" XSTR(CODEXL_ACTIVITY_LOGGER_HEADER));
+  #endif
 }

--- a/lib/Driver/ToolChains/Gnu.h
+++ b/lib/Driver/ToolChains/Gnu.h
@@ -345,6 +345,7 @@ private:
 
 class LLVM_LIBRARY_VISIBILITY Generic_ELF : public Generic_GCC {
   virtual void anchor();
+  mutable std::string HCCIncludePath;
 
 public:
   Generic_ELF(const Driver &D, const llvm::Triple &Triple,

--- a/lib/Driver/ToolChains/Hcc.h
+++ b/lib/Driver/ToolChains/Hcc.h
@@ -80,6 +80,9 @@ public:
 
 // \brief C++AMP linker.
 class LLVM_LIBRARY_VISIBILITY CXXAMPLink : public gnutools::Linker {
+  mutable std::string HCCLibPath;
+  mutable std::string HCCRLibPath;
+  
 public:
   CXXAMPLink(const ToolChain &TC) : Linker(TC, "clamp-link") {}
 


### PR DESCRIPTION
This change removes the need to use hcc-config when compiling with hcc. All of the options (except for 'hc' and 'std=c++amp') added by --cxxflags and --ldflags are now being included inside the hcc tool chain. To invoke hcc in build mode, instead of setting the --build flag in hcc-config, now it is required to set the HCC_BUILD environmental variable.