### PR TITLE
Integrate hcc-config as part of the driver

### DIFF
--- a/lib/Driver/ToolChains/Gnu.cpp
+++ b/lib/Driver/ToolChains/Gnu.cpp
@@ -29,6 +29,8 @@
 #include "llvm/Support/TargetParser.h"
 #include <system_error>
 
+#include "hcc_config.hxx"
+
 using namespace clang::driver;
 using namespace clang::driver::toolchains;
 using namespace clang;
@@ -2392,4 +2394,29 @@ void Generic_ELF::addClangTargetOptions(const ArgList &DriverArgs,
   if (DriverArgs.hasFlag(options::OPT_fuse_init_array,
                          options::OPT_fno_use_init_array, UseInitArrayDefault))
     CC1Args.push_back("-fuse-init-array");
+
+  if (Driver::IsCXXAMP(DriverArgs))
+  {
+    if (getenv("HCC_BUILD")) {
+      CC1Args.push_back("-I" CMAKE_BUILD_INC_DIR);
+    }
+    else {
+      std::string path_hcc_include;
+
+      if (const char *p = getenv("HCC_HOME")) {
+        path_hcc_include = std::string(p) + std::string("/include");
+      }
+      else {
+        CC1Args.push_back("-I" CMAKE_ROCM_ROOT "/include");
+        path_hcc_include = getDriver().Dir + "/../../include";
+      }
+
+      HCCIncludePath = "-I" + path_hcc_include;
+      CC1Args.push_back(HCCIncludePath.c_str());
+    }
+
+    #ifdef CODEXL_ACTIVITY_LOGGER_ENABLED
+      CC1Args.push_back("-I" XSTR(CODEXL_ACTIVITY_LOGGER_HEADER));
+    #endif
+  }
 }

--- a/lib/Driver/ToolChains/Gnu.h
+++ b/lib/Driver/ToolChains/Gnu.h
@@ -345,6 +345,7 @@ private:
 
 class LLVM_LIBRARY_VISIBILITY Generic_ELF : public Generic_GCC {
   virtual void anchor();
+  mutable std::string HCCIncludePath;
 
 public:
   Generic_ELF(const Driver &D, const llvm::Triple &Triple,

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -17,6 +17,8 @@
 #include "llvm/Option/ArgList.h"
 #include "llvm/Support/Path.h"
 
+#include "hcc_config.hxx"
+
 #include <array>
 #include <cstdio>
 #include <cstdlib>
@@ -324,6 +326,55 @@ void HCC::CXXAMPLink::ConstructJob(
 
     // specify AMDGPU target
     constexpr const char auto_tgt[] = "auto";
+
+    if (getenv("HCC_BUILD")) {
+        CmdArgs.push_back("-L" CMAKE_BUILD_LIB_DIR);
+        CmdArgs.push_back("--rpath=" CMAKE_BUILD_LIB_DIR);
+
+        CmdArgs.push_back("-L" CMAKE_BUILD_COMPILER_RT_LIB_DIR);
+        CmdArgs.push_back("--rpath=" CMAKE_BUILD_COMPILER_RT_LIB_DIR);
+    }
+    else {
+        std::string path_hcc_lib;
+
+        if (const char *p = getenv("HCC_HOME")) {
+            path_hcc_lib = std::string(p) + std::string("/lib");
+        }
+        else {
+            path_hcc_lib = C.getDriver().Dir + "/../../" + CMAKE_INSTALL_LIB;
+        }
+
+        HCCLibPath = "-L" + path_hcc_lib;
+        CmdArgs.push_back(HCCLibPath.c_str());
+
+        HCCRLibPath = "--rpath=" + path_hcc_lib;
+        CmdArgs.push_back(HCCRLibPath.c_str());
+    }
+
+    #ifdef USE_LIBCXX
+        CmdArgs.push_back("-stdlib=libc++");
+        CmdArgs.push_back("-lc++");
+        CmdArgs.push_back("-lc++abi");
+    #endif
+
+    CmdArgs.push_back("-ldl");
+    CmdArgs.push_back("-lm");
+    CmdArgs.push_back("-lpthread");
+    CmdArgs.push_back("-lunwind");
+
+    if (const char *p = getenv("TEST_CPU"))
+        if (p == std::string("ON"))
+            CmdArgs.push_back("-lmcwamp_atomic");
+
+    CmdArgs.push_back("--whole-archive");
+    CmdArgs.push_back("-lmcwamp");
+    CmdArgs.push_back("--no-whole-archive");
+
+    #ifdef CODEXL_ACTIVITY_LOGGER_ENABLED
+        CmdArgs.push_back("-L" XSTR(CODEXL_ACTIVITY_LOGGER_LIBRARY));
+        CmdArgs.push_back("-lCXLActivityLogger");
+    #endif
+
 
     #if !defined(HCC_AMDGPU_TARGET)
         #define HCC_AMDGPU_TARGET auto_tgt

--- a/lib/Driver/ToolChains/Hcc.h
+++ b/lib/Driver/ToolChains/Hcc.h
@@ -80,6 +80,9 @@ public:
 
 // \brief C++AMP linker.
 class LLVM_LIBRARY_VISIBILITY CXXAMPLink : public gnutools::Linker {
+  mutable std::string HCCLibPath;
+  mutable std::string HCCRLibPath;
+
 public:
   CXXAMPLink(const ToolChain &TC) : Linker(TC, "clamp-link") {}
 


### PR DESCRIPTION
This change removes the need to use hcc-config when compiling with hcc. All of the options (except for 'hc' and 'std=c++amp') added by --cxxflags and --ldflags are now being included inside the hcc tool chain. To invoke hcc in build mode, instead of setting the --build flag in hcc-config, now it is required to set the HCC_BUILD environmental variable.