### PR TITLE
[CodeGen] add thrust methods into whitelist

### DIFF
--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -2088,7 +2088,8 @@ static bool isWhiteListForHCC(CodeGenModule &CGM, GlobalDecl GD) {
         ClassName.find("numeric_limits") != StringRef::npos ||
         ClassName.find("pair") != StringRef::npos ||
         ClassName.find("complex") != StringRef::npos ||
-        MangledName.find("experimental8parallel") != StringRef::npos) {
+        MangledName.find("experimental8parallel") != StringRef::npos ||
+        MangledName.find("6thrust") != StringRef::npos) {
       return true;
     }
   }


### PR DESCRIPTION
This PR helps to make certain thrust test applications to build. It is not as effective as #62 . But could be used as a workaround before #62 is fully adopted.