### PR TITLE
Fix lambda with empty capture list

### DIFF
--- a/lib/CodeGen/CGAMPRuntime.h
+++ b/lib/CodeGen/CGAMPRuntime.h
@@ -37,6 +37,12 @@ public:
                                   FunctionArgList &Args);
   void EmitTrampolineNameBody(CodeGenFunction &CGF, const FunctionDecl *FD,
     FunctionArgList &Args);
+
+private:
+
+  void EmitCXXAMPDeserializer(CodeGenFunction &CGF,
+                              const FunctionDecl *Trampoline, 
+                              FunctionArgList& Args, Address& ai);
 };
 
 /// Creates an instance of a C++ AMP runtime class.


### PR DESCRIPTION
- This fixes the issue where hcc doesn't generate the kernel body when PFE lambda's capture list is empty
- This also fixes the issue when a lambda doesn't take an index object as parameter