### PR TITLE
[Driver] remove x86_64 dependency in compiler-rt

### DIFF
--- a/lib/Driver/ToolChains/Gnu.cpp
+++ b/lib/Driver/ToolChains/Gnu.cpp
@@ -524,7 +524,9 @@ void tools::gnutools::Linker::ConstructLinkerJob(Compilation &C,
 
   // HCC: Add compiler-rt library to get the half fp builtins 
   if (Driver::IsCXXAMP(C.getArgs())) {
-    CmdArgs.push_back("-lclang_rt.builtins-x86_64");
+    CmdArgs.push_back(Args.MakeArgString(
+        "-lclang_rt.builtins-" +
+        getToolChain().getTriple().getArchName()));
   }
 
   // Add OpenMP offloading linker script args if required.


### PR DESCRIPTION
This is a precursor to allow HCC be built to support different host archs.

`make test` passes on x86 system.