### PR TITLE
remove using sysroot in Hcc toolchain to find ROCm agent enumerator

### DIFF
--- a/lib/Driver/ToolChains/Gnu.cpp
+++ b/lib/Driver/ToolChains/Gnu.cpp
@@ -524,7 +524,9 @@ void tools::gnutools::Linker::ConstructLinkerJob(Compilation &C,
 
   // HCC: Add compiler-rt library to get the half fp builtins 
   if (Driver::IsCXXAMP(C.getArgs())) {
-    CmdArgs.push_back("-lclang_rt.builtins-aarch64");
+    CmdArgs.push_back(Args.MakeArgString(
+        "-lclang_rt.builtins-" +
+        getToolChain().getTriple().getArchName()));
   }
 
   // Add OpenMP offloading linker script args if required.

--- a/lib/Driver/ToolChains/Gnu.cpp
+++ b/lib/Driver/ToolChains/Gnu.cpp
@@ -524,7 +524,7 @@ void tools::gnutools::Linker::ConstructLinkerJob(Compilation &C,
 
   // HCC: Add compiler-rt library to get the half fp builtins 
   if (Driver::IsCXXAMP(C.getArgs())) {
-    CmdArgs.push_back("-lclang_rt.builtins-x86_64");
+    CmdArgs.push_back("-lclang_rt.builtins-aarch64");
   }
 
   // Add OpenMP offloading linker script args if required.

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -188,9 +188,8 @@ namespace
         std::vector<std::string> r;
 
         const char* tmp = std::getenv("ROCM_ROOT");
-        const char* rocm = tmp ? tmp : "/opt/rocm";
-
-        const auto e = c.getSysRoot() + rocm + "/bin/rocm_agent_enumerator";
+        const Twine rocm = tmp ? tmp : "/opt/rocm";
+        const Twine e = rocm + "/bin/rocm_agent_enumerator";
 
         if (!tc.getVFS().exists(e)) return r;
 


### PR DESCRIPTION
It is observed Compilation.getSysRoot() would return incorrect value on
non-x86 systems such as aarch64. Abolish using it in this PR.