### PR TITLE
__global__ functions as kernels

### DIFF
--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -2164,12 +2164,10 @@ void CodeGenModule::EmitGlobalDefinition(GlobalDecl GD, llvm::GlobalValue *GV) {
       // If -famp-is-device switch is on, we are in GPU build path.
       if (!isWhiteListForHCC(*this, GD)) return;
     }
-    else {
-      if (!isa<VarDecl>(D) &&
-          D->hasAttr<CXXAMPRestrictAMPAttr>() &&
-          !D->hasAttr<CXXAMPRestrictCPUAttr>()) {
-        return;
-      }
+    else if (!isa<VarDecl>(D) &&
+      D->hasAttr<CXXAMPRestrictAMPAttr>() &&
+      !D->hasAttr<CXXAMPRestrictCPUAttr>()) {
+      return;
     }
   }
 


### PR DESCRIPTION
This implements the FE support needed for generalised usage of__global__ 
functions as kernel entry points in HIP. The change is pretty boring and 
relies on the presence of a "__HIP_global_function__" annotation that 
HIP adds as a consequence of marking a function __global__. At the same 
time, we do not emit the body of __global__ functions on host, since it 
may contain host incompatible code, and the only thing we need from them 
is a valid address in the generated ELF.