### PR TITLE
Correct oversight in generic function attribute implementation

### DIFF
--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -7713,8 +7713,6 @@ void AMDGPUTargetCodeGenInfo::setTargetAttributes(
     llvm::APSInt min = getConstexprInt(Attr->getMin(), FD->getASTContext());
     llvm::APSInt max = getConstexprInt(Attr->getMax(), FD->getASTContext());
 
-    Attr->getMin()->dump();
-    Attr->getMax()->dump();
     unsigned Min = min.getZExtValue();
     unsigned Max = std::max(min, max).getZExtValue();
 

--- a/lib/Sema/SemaDeclAttr.cpp
+++ b/lib/Sema/SemaDeclAttr.cpp
@@ -5607,9 +5607,9 @@ static void handleAMDGPUFlatWorkGroupSizeAttr(Sema &S, Decl *D,
       !checkUInt32Argument(S, Attr, MinExpr, Min))
     return;
 
-  uint32_t Max = 0;
+  uint32_t Max = Min;
   Expr *MaxExpr = MinExpr;
-  if (Attr.getNumArgs() > 1 ) {
+  if (Attr.getNumArgs() > 1) {
     MaxExpr = Attr.getArgAsExpr(1);
     if (MaxExpr->isEvaluatable(S.Context) &&
         !checkUInt32Argument(S, Attr, MaxExpr, Max))
@@ -5646,7 +5646,7 @@ static void handleAMDGPUWavesPerEUAttr(Sema &S, Decl *D,
       !checkUInt32Argument(S, Attr, MinExpr, Min))
     return;
 
-  uint32_t Max = 0;
+  uint32_t Max = Min;
   Expr *MaxExpr = MinExpr;
   if (Attr.getNumArgs() > 1) {
     MaxExpr = Attr.getArgAsExpr(1);


### PR DESCRIPTION
This corrects two oversights which crept into the implementation of generic function 
attributes. One is trivial, a pair of useless calls to dump() were left in TargetInfo.cpp. 
The other is more subtle: it is valid for the user to pass an integer literal as the 
minimum and a dependent expression as the maximum for e.g. 
AMDGPUFlatWorkgroupSize. As things were this would trigger an error, as the 
maximum could not be evaluated early and would yield 0, which then would be 
compared to a positive minimum and break the invariant of the attribute. As a 
change, the maximum is assumed to be at least equal to the minimum. If it can be
evaluated and it actually is less, then this is an error. If it cannot be evaluated it is 
still assumed to be at least equal to the minimum and not breaking the invariant. 
This completes support for generic function attributes, as verified by proxy in the 
context of implementing CUDA equivalent __launch_bounds__.