### PR TITLE
Disable sanitizers on device code

### DIFF
--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -866,7 +866,7 @@ void CodeGenFunction::StartFunction(GlobalDecl GD,
     for (auto Attr : D->specific_attrs<NoSanitizeAttr>())
       SanOpts.Mask &= ~Attr->getMask();
     // Device code has all sanitizers disabled for now
-    for (auto Attr : D->specific_attrs<CXXAMPRestrictAMPAttr>())
+    if (D->hasAttr<CXXAMPRestrictAMPAttr>())
       SanOpts.clear();
 
   }

--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -865,6 +865,10 @@ void CodeGenFunction::StartFunction(GlobalDecl GD,
     // Apply the no_sanitize* attributes to SanOpts.
     for (auto Attr : D->specific_attrs<NoSanitizeAttr>())
       SanOpts.Mask &= ~Attr->getMask();
+    // Device code has all sanitizers disabled for now
+    for (auto Attr : D->specific_attrs<CXXAMPRestrictAMPAttr>())
+      SanOpts.clear();
+
   }
 
   // Apply sanitizer attributes to the function.


### PR DESCRIPTION
This is a fix or workaround for the llvm errors that happen from device code when the sanitizers are enabled. 

We may want to look into enabling the sanitizers on the gpu at a later time, but this will at least let us use the sanitizers on the host(which is still very useful).