### PR TITLE
Default to using the ROCm hcc installation if no other are found

### DIFF
--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -47,9 +47,9 @@ HCCInstallationDetector::HCCInstallationDetector(const Driver &D, const llvm::op
     HCCPathCandidates.push_back(
       Args.getLastArgValue(options::OPT_hcc_path_EQ));
     
-  HCCPathCandidates.push_back(InstallPath + "/..");
-  HCCPathCandidates.push_back(BinPath + "/..");
   HCCPathCandidates.push_back(BinPath + "/../..");
+  HCCPathCandidates.push_back(InstallPath + "/..");
+  HCCPathCandidates.push_back(RocmInstallation + "/hcc");
 
   for (const auto &HCCPath: HCCPathCandidates) {
     if (HCCPath.empty() ||
@@ -68,7 +68,8 @@ HCCInstallationDetector::HCCInstallationDetector(const Driver &D, const llvm::op
 void HCCInstallationDetector::AddHCCIncludeArgs(const llvm::opt::ArgList &DriverArgs, llvm::opt::ArgStringList &CC1Args) const {
   if (IsValid) {
     CC1Args.push_back(DriverArgs.MakeArgString("-I" + IncPath + "/include"));
-    CC1Args.push_back(DriverArgs.MakeArgString("-I" + IncPath + "/hcc/include"));
+    // fall back to /opt/rocm/include if the user includes <hcc/hc.hpp>
+    CC1Args.push_back(DriverArgs.MakeArgString("-I" + RocmInstallation + "/include"));
   }
 }
 

--- a/lib/Driver/ToolChains/Hcc.h
+++ b/lib/Driver/ToolChains/Hcc.h
@@ -30,6 +30,7 @@ private:
   std::string IncPath;
   std::string LibPath;
 
+  const std::string RocmInstallation = "/opt/rocm";
   std::vector<const char *> SystemLibs = {"-ldl", "-lm", "-lpthread", "-lunwind"};
   std::vector<const char *> RuntimeLibs = {"-lhc_am", "-lmcwamp"};
 


### PR DESCRIPTION
This commit changes the search order for a hcc installation. The new order is the following:

1. Use the path provided by `--hcc-path=`
2. Follow symlinks and look starting from the directory hcc was installed
3. Look starting from the directory hcc was launched
4. Look starting from `/opt/rocm/hcc`