### PR TITLE
Give C++AMP/HC serializer weak_odr linkage

### DIFF
--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -990,6 +990,15 @@ void CodeGenFunction::StartFunction(GlobalDecl GD,
     }
   }
 
+  if (getLangOpts().CPlusPlusAMP) {
+    if (const FunctionDecl *FD = dyn_cast_or_null<FunctionDecl>(D)) {
+      if (FD->hasAttr<AnnotateAttr>() &&
+          FD->getAttr<AnnotateAttr>()->getAnnotation() == "serialize") {
+        Fn->setLinkage(llvm::Function::LinkageTypes::WeakODRLinkage);
+      }
+    }
+  }
+
   // If we are checking function types, emit a function type signature as
   // prologue data.
   if (getLangOpts().CPlusPlus && SanOpts.has(SanitizerKind::Function)) {


### PR DESCRIPTION
Serialization function should have weak linkage in order to
avoid symbol collisions when linking with objects from
different translation units and they should have exactly
the same code anyway.

Change-Id: Ib5740044e0edda059c4dabc212b1dd9943b067a3