### PR TITLE
Remove unsupported targets gfx801 and gfx802

### DIFF
--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -308,8 +308,7 @@ namespace
     bool is_valid(const std::string& gfxip)
     {
         static constexpr std::array<const char*, 7u> valid = {
-            { "gfx700", "gfx701", "gfx801", "gfx802", "gfx803", "gfx900",
-              "gfx901" }};
+            { "gfx700", "gfx701", "gfx803", "gfx900", "gfx901" }};
 
         return std::find(valid.cbegin(), valid.cend(), gfxip) != valid.cend();
     }

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -307,8 +307,8 @@ namespace
 
     bool is_valid(const std::string& gfxip)
     {
-        static constexpr std::array<const char*, 7u> valid = {
-            { "gfx700", "gfx701", "gfx803", "gfx900", "gfx901" }};
+        static constexpr std::array<const char*, 3u> valid = {
+            { "gfx701", "gfx803", "gfx900" }};
 
         return std::find(valid.cbegin(), valid.cend(), gfxip) != valid.cend();
     }


### PR DESCRIPTION
These architectures are no longer supported. Should not compile for them.