### PR TITLE
[HCC] Get rid of static bool IsCXXAMP(...) method in class clang::driver::Driver

### DIFF
--- a/include/clang/Driver/Driver.h
+++ b/include/clang/Driver/Driver.h
@@ -314,8 +314,6 @@ public:
     return ClangExecutable.c_str();
   }
 
-  static bool IsCXXAMP(const llvm::opt::ArgList& Args);
-
   /// Get the path to where the clang executable was installed.
   const char *getInstalledDir() const {
     if (!InstalledDir.empty())

--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -392,31 +392,11 @@ DerivedArgList *Driver::TranslateInputArgs(const InputArgList &Args) const {
     if (!Args.hasArg(options::OPT_std_EQ)) {
       DAL->AddPositionalArg(0, Opts->getOption(options::OPT_std_EQ), "c++amp");
     }
-  }
-
-  if (Args.hasArg(options::OPT_famp)) {
+  } else if (Args.hasArg(options::OPT_famp)) {
     DAL->AddPositionalArg(0, Opts->getOption(options::OPT_Xclang), "-famp");
   }
 
   return DAL;
-}
-
-// test if we are in C++AMP mode
-bool Driver::IsCXXAMP(const ArgList& Args) {
-  if (Args.hasArg(options::OPT_famp)) {
-    return true;
-  }
-
-  for (ArgList::const_iterator it = Args.begin(), ie = Args.end();
-       it != ie; ++it) {
-    Arg* A = *it;
-    if (A->getOption().getName().compare("std=") == 0 &&
-        A->getNumValues() == 1 &&
-        std::string("c++amp").compare(A->getValue(0)) == 0) {
-      return true;
-    }
-  }
-  return false;
 }
 
 /// Compute target triple from args.
@@ -2064,7 +2044,9 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
         // C++ AMP-specific
         // For C++ source files, duplicate the input so we launch the compiler twice
         // 1 for GPU compilation (TY_CXX_AMP), 1 for CPU compilation (TY_CXX)
-        if (IsCXXAMP(Args) && (Ty == types::TY_CXX)) {
+        if ((Args.hasArg(options::OPT_famp) ||
+          llvm::any_of(Args.getAllArgValues(options::OPT_std_EQ),
+          [](std::string s) { return s == "c++amp"; })) && Ty == types::TY_CXX) {
           Arg *FinalPhaseArg;
           phases::ID FinalPhase = getFinalPhase(Args, &FinalPhaseArg);
           switch (FinalPhase) {
@@ -3240,9 +3222,6 @@ Action *Driver::ConstructPhaseAction(
   llvm_unreachable("invalid phase in ConstructPhaseAction");
 }
 
-// UPGRADE_TBD: see if it's possible to get rid of this check
-extern bool IsCXXAMPBackendJobAction(const JobAction* A);
-
 void Driver::BuildJobs(Compilation &C) const {
   llvm::PrettyStackTraceString CrashInfo("Building compilation jobs");
 
@@ -3258,7 +3237,9 @@ void Driver::BuildJobs(Compilation &C) const {
 
     if (NumOutputs > 1) {
       // relax rule for C++AMP because we may have multiple outputs
-      if (!IsCXXAMP(C.getArgs())) {
+      if (!C.getArgs().hasArg(options::OPT_famp) &&
+        !llvm::any_of(C.getArgs().getAllArgValues(options::OPT_std_EQ),
+        [](std::string s) { return s == "c++amp"; })) {
         Diag(clang::diag::err_drv_output_argument_with_multiple_files);
         FinalOutput = nullptr;
       }

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -1076,7 +1076,9 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
   if (JA.isOffloading(Action::OFK_Cuda))
     getToolChain().AddCudaIncludeArgs(Args, CmdArgs);
 
-  if (D.IsCXXAMP(Args))
+  if (Args.hasArg(options::OPT_famp) ||
+    llvm::any_of(Args.getAllArgValues(options::OPT_std_EQ), [](std::string s)
+    { return s == "c++amp"; }))
     getToolChain().AddHCCIncludeArgs(Args, CmdArgs);
 
   // Add -i* options, and automatically translate to
@@ -3177,7 +3179,9 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.hasArg(options::OPT_hc_mode)) {
     CmdArgs.push_back("-D__KALMAR_HC__=1");
     CmdArgs.push_back("-D__HCC_HC__=1");
-  } else if (D.IsCXXAMP(Args)) {
+  } else if (Args.hasArg(options::OPT_famp) ||
+    llvm::any_of(Args.getAllArgValues(options::OPT_std_EQ), [](std::string s)
+    { return s == "c++amp"; })) {
     CmdArgs.push_back("-D__KALMAR_AMP__=1");
     CmdArgs.push_back("-D__HCC_AMP__=1");
   }

--- a/lib/Driver/ToolChains/Gnu.cpp
+++ b/lib/Driver/ToolChains/Gnu.cpp
@@ -534,8 +534,10 @@ void tools::gnutools::Linker::ConstructLinkerJob(Compilation &C,
     }
   }
 
-  // HCC: Add compiler-rt library to get the half fp builtins 
-  if (Driver::IsCXXAMP(C.getArgs())) {
+  // HCC: Add compiler-rt library to get the half fp builtins
+  if (C.getArgs().hasArg(options::OPT_famp) ||
+    llvm::any_of(C.getArgs().getAllArgValues(options::OPT_std_EQ),
+    [](std::string s) { return s == "c++amp"; })) {
     CmdArgs.push_back(Args.MakeArgString(
         "-lclang_rt.builtins-" +
         getToolChain().getTriple().getArchName()));
@@ -553,7 +555,9 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C,
                                     const char *LinkingOutput) const {
   // ToDo: Find a better way to persist CXXAMPLink and construct the link
   // job using it.
-  if (Driver::IsCXXAMP(C.getArgs())) {
+  if (C.getArgs().hasArg(options::OPT_famp) ||
+    llvm::any_of(C.getArgs().getAllArgValues(options::OPT_std_EQ),
+    [](std::string s) { return s == "c++amp"; })) {
     ArgStringList CmdArgs;
 
     if (!HCLinker)


### PR DESCRIPTION
IsCXXAMP(...) method was replaced on conditions with lambda in place. No regressions.