### PR TITLE
[HCC] Simplify checks on -std=c++amp

### DIFF
--- a/lib/Driver/Driver.cpp
+++ b/lib/Driver/Driver.cpp
@@ -2044,9 +2044,8 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
         // C++ AMP-specific
         // For C++ source files, duplicate the input so we launch the compiler twice
         // 1 for GPU compilation (TY_CXX_AMP), 1 for CPU compilation (TY_CXX)
-        if ((Args.hasArg(options::OPT_famp) ||
-          llvm::any_of(Args.getAllArgValues(options::OPT_std_EQ),
-          [](std::string s) { return s == "c++amp"; })) && Ty == types::TY_CXX) {
+        if (Ty == types::TY_CXX && (Args.hasArg(options::OPT_famp) ||
+          Args.getLastArgValue(options::OPT_std_EQ).equals("c++amp"))) {
           Arg *FinalPhaseArg;
           phases::ID FinalPhase = getFinalPhase(Args, &FinalPhaseArg);
           switch (FinalPhase) {
@@ -3238,8 +3237,7 @@ void Driver::BuildJobs(Compilation &C) const {
     if (NumOutputs > 1) {
       // relax rule for C++AMP because we may have multiple outputs
       if (!C.getArgs().hasArg(options::OPT_famp) &&
-        !llvm::any_of(C.getArgs().getAllArgValues(options::OPT_std_EQ),
-        [](std::string s) { return s == "c++amp"; })) {
+        !C.getArgs().getLastArgValue(options::OPT_std_EQ).equals("c++amp")) {
         Diag(clang::diag::err_drv_output_argument_with_multiple_files);
         FinalOutput = nullptr;
       }

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -1077,8 +1077,7 @@ void Clang::AddPreprocessingOptions(Compilation &C, const JobAction &JA,
     getToolChain().AddCudaIncludeArgs(Args, CmdArgs);
 
   if (Args.hasArg(options::OPT_famp) ||
-    llvm::any_of(Args.getAllArgValues(options::OPT_std_EQ), [](std::string s)
-    { return s == "c++amp"; }))
+    Args.getLastArgValue(options::OPT_std_EQ).equals("c++amp"))
     getToolChain().AddHCCIncludeArgs(Args, CmdArgs);
 
   // Add -i* options, and automatically translate to
@@ -3180,8 +3179,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-D__KALMAR_HC__=1");
     CmdArgs.push_back("-D__HCC_HC__=1");
   } else if (Args.hasArg(options::OPT_famp) ||
-    llvm::any_of(Args.getAllArgValues(options::OPT_std_EQ), [](std::string s)
-    { return s == "c++amp"; })) {
+    Args.getLastArgValue(options::OPT_std_EQ).equals("c++amp")) {
     CmdArgs.push_back("-D__KALMAR_AMP__=1");
     CmdArgs.push_back("-D__HCC_AMP__=1");
   }

--- a/lib/Driver/ToolChains/Gnu.cpp
+++ b/lib/Driver/ToolChains/Gnu.cpp
@@ -536,8 +536,7 @@ void tools::gnutools::Linker::ConstructLinkerJob(Compilation &C,
 
   // HCC: Add compiler-rt library to get the half fp builtins
   if (C.getArgs().hasArg(options::OPT_famp) ||
-    llvm::any_of(C.getArgs().getAllArgValues(options::OPT_std_EQ),
-    [](std::string s) { return s == "c++amp"; })) {
+    C.getArgs().getLastArgValue(options::OPT_std_EQ).equals("c++amp")) {
     CmdArgs.push_back(Args.MakeArgString(
         "-lclang_rt.builtins-" +
         getToolChain().getTriple().getArchName()));
@@ -556,8 +555,7 @@ void tools::gnutools::Linker::ConstructJob(Compilation &C,
   // ToDo: Find a better way to persist CXXAMPLink and construct the link
   // job using it.
   if (C.getArgs().hasArg(options::OPT_famp) ||
-    llvm::any_of(C.getArgs().getAllArgValues(options::OPT_std_EQ),
-    [](std::string s) { return s == "c++amp"; })) {
+    C.getArgs().getLastArgValue(options::OPT_std_EQ).equals("c++amp")) {
     ArgStringList CmdArgs;
 
     if (!HCLinker)


### PR DESCRIPTION
Instead of lambdas checking any_of -std=c++amp the getLastArgValue method is used.

[Reason] Only last -std= occurrence in a command line make sense to check, so change fixes correctness and performance a bit.

No regressions.