### PR TITLE
Turn off uniform work group size when compiling in HC mode

### DIFF
--- a/lib/CodeGen/CGCall.cpp
+++ b/lib/CodeGen/CGCall.cpp
@@ -1904,7 +1904,8 @@ void CodeGenModule::ConstructAttributeList(
   }
 
   if (TargetDecl && TargetDecl->hasAttr<OpenCLKernelAttr>()) {
-    if (getLangOpts().OpenCLVersion <= 120) {
+    if (getLangOpts().OpenCL &&
+        getLangOpts().OpenCLVersion <= 120) {
       // OpenCL v1.2 Work groups are always uniform
       FuncAttrs.addAttribute("uniform-work-group-size", "true");
     } else {

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -696,6 +696,7 @@ static bool ParseCodeGenArgs(CodeGenOptions &Opts, ArgList &Args, InputKind IK,
   Opts.CorrectlyRoundedDivSqrt =
       Args.hasArg(OPT_cl_fp32_correctly_rounded_divide_sqrt);
   Opts.UniformWGSize =
+      !Args.hasArg(OPT_famp_is_device) &&
       Args.hasArg(OPT_cl_uniform_work_group_size);
   Opts.Reciprocals = Args.getAllArgValues(OPT_mrecip_EQ);
   Opts.ReciprocalMath = Args.hasArg(OPT_freciprocal_math);


### PR DESCRIPTION
HC supports non-uniform group size by default and there's no
option to turn it off.  When compiling in HC, make sure to
disable the UniformWGSize option to ensure correct code is
being generated.