### PR TITLE
Only parse body of restricted function when compiling in restricted context

### DIFF
--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -13194,7 +13194,7 @@ Sema::ActOnStartOfFunctionDef(Scope *FnBodyScope, Declarator &D,
     const bool IsCPU = DP->hasAttr<CXXAMPRestrictCPUAttr>();
 
     SkipBody->ShouldSkip =
-      !IsAuto && LangOpts.DevicePath ? (!IsHC && IsCPU) : (IsHC && !IsCPU);
+      !IsAuto && (LangOpts.DevicePath ? (!IsHC && IsCPU) : (IsHC && !IsCPU));
 
     if (SkipBody->ShouldSkip) {
       auto Empty = new (getASTContext()) NullStmt{DP->getLocation()};

--- a/lib/Sema/SemaDecl.cpp
+++ b/lib/Sema/SemaDecl.cpp
@@ -13187,6 +13187,23 @@ Sema::ActOnStartOfFunctionDef(Scope *FnBodyScope, Declarator &D,
 
   D.setFunctionDefinitionKind(FDK_Definition);
   Decl *DP = HandleDeclarator(ParentScope, D, TemplateParameterLists);
+
+  if (LangOpts.CPlusPlusAMP && SkipBody) {
+    const bool IsAuto = DP->hasAttr<CXXAMPRestrictAUTOAttr>();
+    const bool IsHC = DP->hasAttr<CXXAMPRestrictAMPAttr>();
+    const bool IsCPU = DP->hasAttr<CXXAMPRestrictCPUAttr>();
+
+    SkipBody->ShouldSkip =
+      !IsAuto && LangOpts.DevicePath ? (!IsHC && IsCPU) : (IsHC && !IsCPU);
+
+    if (SkipBody->ShouldSkip) {
+      auto Empty = new (getASTContext()) NullStmt{DP->getLocation()};
+      cast<FunctionDecl>(DP)->setBody(Empty);
+      cast<FunctionDecl>(DP)->addAttr(CXX11NoReturnAttr::CreateImplicit(getASTContext()));
+      return DP;
+    }
+  }
+
   return ActOnStartOfFunctionDef(FnBodyScope, DP, SkipBody);
 }
 


### PR DESCRIPTION
At the moment we still parse and semantically analyse the body of a [[cpu]] only restricted function when compiling for accelerator or, conversely, a [[hc]] only function when compiling for host. This can lead to subtle issues when e.g. using AMDGCN builtins. This avoids that behaviour by way of eviscerating functions who are in this situation, thus retaining their impact on mangling whilst not exposing guts that are target specific. The suggested solution appears reasonable, if rather yucktastic in terms of the amount of code (an alternative would be to skip such declarations completely, but that may be surprising in terms of mangling across targets); I'd be happy if anyone had a better / cleaner solution. Thanks to @sameerds for discovering this. 