### PR TITLE
Disable sanitizers on device pass not just on device functions

### DIFF
--- a/lib/CodeGen/CodeGenFunction.cpp
+++ b/lib/CodeGen/CodeGenFunction.cpp
@@ -882,10 +882,10 @@ void CodeGenFunction::StartFunction(GlobalDecl GD,
         SanOpts.set(SanitizerKind::HWAddress, false);
     }
 
-    // Device code has all sanitizers disabled for now
-      if (D->hasAttr<CXXAMPRestrictAMPAttr>())
-         SanOpts.clear();
   }
+  // Device code has all sanitizers disabled for now
+  if (CGM.getCodeGenOpts().AMPIsDevice)
+     SanOpts.clear();
 
   // Apply sanitizer attributes to the function.
   if (SanOpts.hasOneOf(SanitizerKind::Address | SanitizerKind::KernelAddress))


### PR DESCRIPTION
Since a lot of functions that are not labeled with `hc` are inlined into device code, just disabling the sanitizers for device functions is not enough.

Also, for functions that are for host and device, its better to have the sanitizer code enabled for the host and disabled for the device.