### PR TITLE
[HCC] Fix HCC Offloading kind

### DIFF
--- a/include/clang/Driver/Action.h
+++ b/include/clang/Driver/Action.h
@@ -88,8 +88,8 @@ public:
     // The device offloading tool chains - one bit for each programming model.
     OFK_Cuda = 0x02,
     OFK_OpenMP = 0x04,
-    OFK_HCC  = 0x05,
     OFK_HIP = 0x08,
+    OFK_HCC = 0x16,
   };
 
   static const char *getClassName(ActionClass AC);


### PR DESCRIPTION
With the merge dca527e9 (2016-12-09) of trunk clang into HCC’s clang_tot_upgrade branch, there were conflicting OFK kinds: OFK_OpenMP and OFK_HCC both equal to 0x04. Conflicting OFK_HCC was changed to 0x05 but had to become 0x08. Later with upstreaming HIP OFK_HIP = 0x08 appeared; thus OFK_HCC should be 0x16.

The issue found with introducing HCC Action Builder (not shipped yet) when HCC offload kind started to be taken entirely into account in offloading routines, including bitwise inclusive OR operations used for Action’s cumulative ActiveOffloadKindMask. Being equal to 0x05 OFK_HCC has begun conflicting with OFK_OpenMP, and HCC toolchain erroneously went to OpenMP in some cases.