### PR TITLE
Clang is all to eager to opaquely pack records - do not do this for HC.

### DIFF
--- a/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -602,18 +602,17 @@ void CGRecordLowering::clipTailPadding() {
   }
 }
 
-static bool isPassedToHIPGlobalFn(const CXXRecordDecl *MaybeLambda)
+static bool isPassedToHIPGlobalFn(const CXXRecordDecl *MaybeKernarg)
 {
-  if (!MaybeLambda) return false;
-  if (!MaybeLambda->isLambda()) return false;
-  if (!MaybeLambda->hasAttr<AnnotateAttr>()) return false;
+  if (!MaybeKernarg) return false;
+  if (!MaybeKernarg->hasAttr<AnnotateAttr>()) return false;
 
   // N.B.: this is set in Sema::GatherArgumentsForCall, via
   //       MarkByValueRecordsPassedToHIPGlobalFN.
-  static constexpr const char HIPKernargLambda[]{"__HIP_KERNARG_LAMBDA__"};
+  static constexpr const char HIPKernargRecord[]{"__HIP_KERNARG_RECORD__"};
 
-  return MaybeLambda->getAttr<AnnotateAttr>()->getAnnotation()
-    .find(HIPKernargLambda) != StringRef::npos;
+  return MaybeKernarg->getAttr<AnnotateAttr>()->getAnnotation()
+    .find(HIPKernargRecord) != StringRef::npos;
 }
 
 void CGRecordLowering::determinePacked(bool NVBaseType) {

--- a/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -631,6 +631,13 @@ void CGRecordLowering::determinePacked(bool NVBaseType) {
   // non-virtual sub-object and an unpacked complete object or vise versa.
   if (NVSize % NVAlignment)
     Packed = true;
+
+  // TODO: this is a heinous workaround the sad reality that passing things by
+  //       value through Kernarg is essentially broken, since the packing choice
+  //       made here is opaque for HLLs, and thus the latter will layout the
+  //       memory erroneously.
+  Packed = Packed && !Context.getLangOpts().CPlusPlusAMP;
+
   // Update the alignment of the sentinel.
   if (!Packed)
     Members.back().Data = getIntNType(Context.toBits(Alignment));

--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -4953,29 +4953,6 @@ Sema::ConvertArgumentsForCall(CallExpr *Call, Expr *Fn,
   return false;
 }
 
-static void MarkByValueRecordsPassedToHIPGlobalFN(FunctionDecl *FDecl)
-{ // TODO: this is a temporary kludge; a preferable solution shall be provided
-  //       in the future, which shall eschew FE involvement. Note that the name
-  //       is misleading as it is not only lambdas that can be affected, and we
-  //       may need to extend it.
-  if (!FDecl) return;
-  if (FDecl->getName() != "hipLaunchKernelGGL") return;
-
-  for (auto &&Parameter : FDecl->parameters()) {
-    if (Parameter->getOriginalType()->isPointerType()) continue;
-    if (Parameter->getOriginalType()->isReferenceType()) continue;
-    if (!Parameter->getOriginalType()->isRecordType()) continue;
-
-    if (auto RD = Parameter->getOriginalType()->getAsCXXRecordDecl()) {
-      if (!RD->isLambda()) continue;
-
-      static constexpr const char HIPKernargLambda[]{"__HIP_KERNARG_LAMBDA__"};
-      RD->addAttr(
-        AnnotateAttr::CreateImplicit(RD->getASTContext(), HIPKernargLambda));
-    }
-  }
-}
-
 bool Sema::GatherArgumentsForCall(SourceLocation CallLoc, FunctionDecl *FDecl,
                                   const FunctionProtoType *Proto,
                                   unsigned FirstParam, ArrayRef<Expr *> Args,
@@ -5078,9 +5055,6 @@ bool Sema::GatherArgumentsForCall(SourceLocation CallLoc, FunctionDecl *FDecl,
     for (Expr *A : Args.slice(ArgIx))
       CheckArrayAccess(A);
   }
-
-  if (getLangOpts().CPlusPlusAMP) MarkByValueRecordsPassedToHIPGlobalFN(FDecl);
-
   return Invalid;
 }
 

--- a/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1595,7 +1595,6 @@ static void MarkByValueRecordsPassedToHIPGlobalFN(FunctionDecl *FDecl)
       static constexpr const char HIPKernargRecord[]{"__HIP_KERNARG_RECORD__"};
       RD->addAttr(
         AnnotateAttr::CreateImplicit(RD->getASTContext(), HIPKernargRecord));
-      RD->dump();
     }
   }
 }


### PR DESCRIPTION
Clang tries to pack records (opaquely) at the slightest provocation. This is a reasonable optimisation, but it is incredibly troublesome in the context of passing kernel arguments by value through kernarg, since the HLL layout would be based on the `alignof` the unpacked record. The current iteration of the fix is terribly coarse, and is put up to allow early testing and validation (this would touch many things). Subsequent commits will narrow down this behaviour to only apply for the case in which a value of type `T` is passed to a `__global__` function, for all such `T`.