### PR TITLE
set AMDGPU atomic properties independent of host triple

### DIFF
--- a/lib/Basic/Targets/AMDGPU.cpp
+++ b/lib/Basic/Targets/AMDGPU.cpp
@@ -265,6 +265,8 @@ AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
     IntPtrType = SignedLong;
   }
 
+  MaxAtomicPromoteWidth = MaxAtomicInlineWidth = 64;
+
   // If possible, get a TargetInfo for our host triple, so we can match its
   // types.
   llvm::Triple HostTriple(Opts.HostTriple);
@@ -325,7 +327,6 @@ AMDGPUTargetInfo::AMDGPUTargetInfo(const llvm::Triple &Triple,
   //   correctly be different on host/device, e.g. if host has wider vector
   //   types than device.
   // - LongDoubleWidth, LongDoubleAlign: TBD
-  MaxAtomicPromoteWidth = MaxAtomicInlineWidth = 64;
 }
 
 void AMDGPUTargetInfo::adjust(LangOptions &Opts) {


### PR DESCRIPTION
The AMDGPU target for clang imports additional properties from the
host target when it is specified with "-aux-triple". But of the
properties, MaxAtomicPromoteWidth and MaxAtomicInlineWidth currently
default to zero when the aux triple is not specified. These should
instead have a useful value.

This default affects the compilation of rocdl, which uses -cl mode
without an -aux-triple. A more consistent fix might be to always
specify aux-triple in hcc, for all languages.