### PR TITLE
Allow constexpr functions and builtins to be used on accelerator.

### DIFF
--- a/lib/Sema/SemaExpr.cpp
+++ b/lib/Sema/SemaExpr.cpp
@@ -5548,7 +5548,7 @@ ExprResult Sema::ActOnConvertVectorExpr(Expr *E, ParsedType ParsedDestTy,
 
 void Sema::DiagnoseCXXAMPMethodCallExpr(SourceLocation LParenLoc,
                                   CXXMethodDecl *Callee) {
-  if(!Callee)
+  if(!Callee || Callee->isConstexpr() || Callee->getBuiltinID() != 0u)
     return;
 
   FunctionDecl* Caller = this->getCurFunctionDecl();

--- a/lib/Sema/SemaOverload.cpp
+++ b/lib/Sema/SemaOverload.cpp
@@ -12366,7 +12366,7 @@ bool Sema::buildOverloadedCallSet(Scope *S, Expr *Fn,
 
 void Sema::DiagnoseCXXAMPOverloadedCallExpr(SourceLocation LParenLoc,
                                             FunctionDecl* Callee) {
-  if(!Callee)
+  if(!Callee || Callee->isConstexpr() || Callee->getBuiltinID() != 0u)
     return;
 
   if(Callee->getQualifiedNameAsString().find("std::")!=std::string::npos)


### PR DESCRIPTION
`constexpr` and builtin functions implicitly meet `[[hc]]` restrictions, so we can allow them in accelerator contexts even absent explicit `[[hc]]`. Note that builtin support for non-`constexpr` builtins is predicated on the BE having an implementation / support.