### PR TITLE
[HCC] Fix debug build

### DIFF
--- a/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1585,7 +1585,8 @@ static void MarkByValueRecordsPassedToHIPGlobalFN(FunctionDecl *FDecl)
 { // TODO: this is a temporary kludge; a preferable solution shall be provided
   //       in the future, which shall eschew FE involvement.
   if (!FDecl) return;
-  if (FDecl->getName() != "hipLaunchKernelGGL") return;
+  if (FDecl->getDeclName().isIdentifier() &&
+    FDecl->getName() != "hipLaunchKernelGGL") return;
 
   for (auto &&Parameter : FDecl->parameters()) {
     if (Parameter->getOriginalType()->isPointerType()) continue;


### PR DESCRIPTION
Not every FunctionDecl is an identifier. Calling getName() from FunctionDecl without isIdentifier() check leads to an assert in NamedDecl::getName() and as a result to failures in more than 2/3 of HCC unit tests.