### PR TITLE
Ensure FlatWGS attribute is not null before inspecting

### DIFF
--- a/lib/CodeGen/TargetInfo.cpp
+++ b/lib/CodeGen/TargetInfo.cpp
@@ -7757,11 +7757,15 @@ void AMDGPUTargetCodeGenInfo::setTargetAttributes(
 
   const auto *FlatWGS = FD->getAttr<AMDGPUFlatWorkGroupSizeAttr>();
   if (ReqdWGS || FlatWGS) {
-    llvm::APSInt min = getConstexprInt(FlatWGS->getMin(), FD->getASTContext());
-    llvm::APSInt max = getConstexprInt(FlatWGS->getMax(), FD->getASTContext());
+    unsigned Min = 0, Max = 0;
+    if (FlatWGS != nullptr) {
+      llvm::APSInt min = getConstexprInt(FlatWGS->getMin(), FD->getASTContext());
+      llvm::APSInt max = getConstexprInt(FlatWGS->getMax(), FD->getASTContext());
 
-    unsigned Min = min.getZExtValue();
-    unsigned Max = std::max(min, max).getZExtValue();
+      Min = min.getZExtValue();
+      Max = std::max(min, max).getZExtValue();
+    }
+
     if (ReqdWGS && Min == 0 && Max == 0)
       Min = Max = ReqdWGS->getXDim() * ReqdWGS->getYDim() * ReqdWGS->getZDim();
 


### PR DESCRIPTION
The lack of this check was causing segfaults for me when compiling some things with `hcc` but not others. My bug hunt narrowed down to failing `miopen-hip` tests on my machine. The larger context is that I have all ROCm pieces compiled from source on NixOS, starting with a build environment including gcc-7.3.0.

Earlier logic in this function as found in upstream `clang` looked like this,

```C++
unsigned Min = FlatWGS ? FlatWGS->getMin() : 0;
unsigned Max = FlatWGS ? FlatWGS->getMax() : 0;
```

but the check that `FlatWGS` is not null was lost along the way.