### PR TITLE
Add another overload resolution step when dealing with `__global__`s.

### DIFF
--- a/lib/CodeGen/CGCall.cpp
+++ b/lib/CodeGen/CGCall.cpp
@@ -1255,8 +1255,10 @@ static llvm::Value *CreateCoercedLoad(Address Src, llvm::Type *Ty,
 
   // Otherwise do coercion through memory. This is stupid, but simple.
   Address Tmp = CreateTempAllocaForCoercion(CGF, Ty, Src.getAlignment());
-  Address Casted = CGF.Builder.CreateBitCast(Tmp, CGF.AllocaInt8PtrTy);
-  Address SrcCasted = CGF.Builder.CreateBitCast(Src, CGF.AllocaInt8PtrTy);
+  Address Casted =
+    CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(Tmp, CGF.AllocaInt8PtrTy);
+  Address SrcCasted =
+    CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(Src, CGF.AllocaInt8PtrTy);
   CGF.Builder.CreateMemCpy(Casted, SrcCasted,
       llvm::ConstantInt::get(CGF.IntPtrTy, SrcSize),
       false);
@@ -1337,8 +1339,10 @@ static void CreateCoercedStore(llvm::Value *Src,
     // to that information.
     Address Tmp = CreateTempAllocaForCoercion(CGF, SrcTy, Dst.getAlignment());
     CGF.Builder.CreateStore(Src, Tmp);
-    Address Casted = CGF.Builder.CreateBitCast(Tmp, CGF.AllocaInt8PtrTy);
-    Address DstCasted = CGF.Builder.CreateBitCast(Dst, CGF.AllocaInt8PtrTy);
+    Address Casted =
+      CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(Tmp, CGF.AllocaInt8PtrTy);
+    Address DstCasted =
+      CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(Dst, CGF.AllocaInt8PtrTy);
     CGF.Builder.CreateMemCpy(DstCasted, Casted,
         llvm::ConstantInt::get(CGF.IntPtrTy, DstSize),
         false);

--- a/lib/CodeGen/CGCleanup.cpp
+++ b/lib/CodeGen/CGCleanup.cpp
@@ -284,7 +284,7 @@ void EHScopeStack::popNullFixups() {
 void CodeGenFunction::initFullExprCleanup() {
   // Create a variable to decide whether the cleanup needs to be run.
   Address active = CreateTempAlloca(Builder.getInt1Ty(), CharUnits::One(),
-                                    "cleanup.cond");
+                                    "cleanup.cond", nullptr, nullptr, false);
 
   // Initialize it to false at a site that's guaranteed to be run
   // before each evaluation.

--- a/lib/Sema/SemaOverload.cpp
+++ b/lib/Sema/SemaOverload.cpp
@@ -12246,6 +12246,83 @@ BuildRecoveryCallExpr(Sema &SemaRef, Scope *S, Expr *Fn,
                                RParenLoc);
 }
 
+static FunctionDecl *getBestCandidateForHIP(Sema &S,
+                                            UnresolvedLookupExpr *ULE,
+                                            MultiExprArg Args) {
+  OverloadCandidateSet CandidateSet{ULE->getLocStart(),
+                                    OverloadCandidateSet::CSK_Normal};
+  S.AddOverloadedCallCandidates(ULE, Args, CandidateSet);
+
+  if (CandidateSet.empty()) return nullptr;
+
+  auto It = CandidateSet.end();
+  CandidateSet.BestViableFunction(S, ULE->getLocStart(), It);
+
+  if (It != CandidateSet.end()) return It->Function;
+
+  It = std::min_element(CandidateSet.begin(), CandidateSet.end(),
+                        [&](const OverloadCandidate &C0,
+                            const OverloadCandidate &C1) {
+    unsigned int Cnt0 = 0;
+    unsigned int Cnt1 = 0;
+
+    for (decltype(Args.size()) I = 0; I != Args.size(); ++I) {
+      Cnt0 += C0.Function->parameters()[I]->getType() != Args[I]->getType();
+      Cnt1 += C1.Function->parameters()[I]->getType() != Args[I]->getType();
+    }
+
+    return Cnt0 < Cnt1;
+  });
+
+  return It->Function;
+}
+
+static void maybeCastArgsForHIPGlobalFunction(Sema &S,
+                                              UnresolvedLookupExpr *ULE,
+                                              MultiExprArg Args) {
+  static constexpr const char HIPLaunch[]{"hipLaunchKernelGGL"};
+
+  if (ULE->getName().getAsString().find(HIPLaunch) == std::string::npos) {
+    return;
+  }
+  if (!isa<UnresolvedLookupExpr>(*Args.begin())) return;
+
+  static constexpr unsigned int IgnoreCnt{5u}; // Skip launch configuration.
+
+  FunctionDecl *FD =
+    getBestCandidateForHIP(S, cast<UnresolvedLookupExpr>(*Args.begin()),
+                           MultiExprArg{Args.begin() + IgnoreCnt, Args.end()});
+
+  if (!FD) return;
+
+  std::transform(FD->param_begin(), FD->param_end(), Args.begin() + IgnoreCnt,
+                 Args.begin() + IgnoreCnt,
+                 [&](const ParmVarDecl *Formal, Expr *Actual) {
+    QualType FormalT = Formal->getType();
+    QualType ActualT = Actual->getType();
+
+    if (FormalT == ActualT) return Actual;
+    if (FormalT->isReferenceType()) return Actual;
+
+    CastKind CK;
+    if (FormalT->isPointerType()) CK = CK_NoOp;
+    if (FormalT->isIntegerType()) {
+      if (ActualT->isIntegerType()) CK = CK_IntegralCast;
+      if (ActualT->isFloatingType()) CK = CK_FloatingToIntegral;
+    }
+    if (FormalT->isFloatingType()) {
+      if (ActualT->isIntegerType()) CK = CK_FloatingToIntegral;
+      if (ActualT->isFloatingType()) CK = CK_FloatingCast;
+    }
+    // TODO: this does not handle UDTs which are convertible either via ctor
+    //       or via an user defined conversion operator, since it is unclear if
+    //       this is a valid case for a __global__ function.
+
+    return cast<Expr>(ImplicitCastExpr::Create(S.Context, FormalT, CK, Actual,
+                                               nullptr, VK_XValue));
+  });
+}
+
 /// Constructs and populates an OverloadedCandidateSet from
 /// the given function.
 /// \returns true when an the ExprResult output parameter has been set.
@@ -12272,6 +12349,10 @@ bool Sema::buildOverloadedCallSet(Scope *S, Expr *Fn,
     assert(getLangOpts().CPlusPlus && "ADL enabled in C");
   }
 #endif
+
+  if (getLangOpts().CPlusPlusAMP) {
+    maybeCastArgsForHIPGlobalFunction(*this, ULE, Args);
+  }
 
   UnbridgedCastsSet UnbridgedCasts;
   if (checkArgPlaceholdersForOverload(*this, Args, UnbridgedCasts)) {

--- a/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1581,8 +1581,10 @@ static QualType adjustFunctionTypeForInstantiation(ASTContext &Context,
 static void MarkByValueRecordsPassedToHIPGlobalFN(FunctionDecl *FDecl)
 { // TODO: this is a temporary kludge; a preferable solution shall be provided
   //       in the future, which shall eschew FE involvement.
+  static constexpr const char HIPLaunch[]{"hipLaunchKernelGGL"};
+
   if (!FDecl) return;
-  if (FDecl->getName() != "hipLaunchKernelGGL") return;
+  if (FDecl->getNameAsString().find(HIPLaunch) == std::string::npos) return;
 
   for (auto &&Parameter : FDecl->parameters()) {
     if (Parameter->getOriginalType()->isPointerType()) continue;


### PR DESCRIPTION
The dispatch mechanism used in HIP relies on template argument deduction, and assumes a certain degree of discipline from the user in what regards argument passing. This latter assumption was optimistic, and led to the proliferation of various unfortunate mechanisms, such as explicit overload selection, which can yield unexpected results. Which leads us to this patch, which implements a poor man's overload resolution mechanism for `__global__` functions, which only fires when we're dealing with a `hipLaunchKernelGGL` callsite, and which only weakly approximates the language rules. However, this is sufficient for the cases we are dealing with at present, and we expect that the magnum opus will be more robust in this area, thus making it redundant.

Separately, and as a bonus, a bunch of issues that oddly enough found their way into the 1.9.x branch, and which could lead to ill-formed IR, are addressed, after they made assertions fire left and right (Debug builds are our friends). We will want to put this in 2.0, but that's a separate PR. 