### PR TITLE
[HCC] Support for the -fno-gpu-rdc flag

### DIFF
--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -5110,6 +5110,20 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-fcuda-short-ptr");
   }
 
+  if (Args.hasArg(options::OPT_hc_mode) ||
+    Args.hasArg(options::OPT_famp) ||
+    Args.getLastArgValue(options::OPT_std_EQ).equals("c++amp")) {
+
+    // Generate *relocatable* code by default for HCC
+    // In reality, HCC doesn't support relocatible code at the moment.
+    // What it really cares about is -fno-gpu-rdc, which instructs
+    // HCC to generate non-relocatable code.  This is a hint for HCC
+    // to enable early finalization because kernels don't contain calls 
+    // to functions defined in another module.
+    if (Args.hasFlag(options::OPT_fgpu_rdc, options::OPT_fno_gpu_rdc, true))
+      CmdArgs.push_back("-fgpu-rdc");
+  }
+
   // OpenMP offloading device jobs take the argument -fopenmp-host-ir-file-path
   // to specify the result of the compile phase on the host, so the meaningful
   // device declarations can be identified. Also, -fopenmp-is-device is passed

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -127,8 +127,11 @@ void HCC::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
     else if (JA.ContainsActions(Action::AssembleJobClass, types::TY_HC_KERNEL))
       assembler = "hc-kernel-assemble";
     else if (JA.ContainsActions(Action::AssembleJobClass, types::TY_PP_CXX_AMP) ||
-      JA.ContainsActions(Action::AssembleJobClass, types::TY_PP_CXX_AMP_CPU))
+      JA.ContainsActions(Action::AssembleJobClass, types::TY_PP_CXX_AMP_CPU)) {
       assembler = "clamp-assemble";
+      // embed the device IR into the .kernel_ir section
+      CmdArgs.push_back(".kernel_ir");
+    }
     else {
       assert(!assembler.empty() && "Unsupported assembler.");
       return;

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -44,7 +44,7 @@ HCCInstallationDetector::HCCInstallationDetector(const Driver &D, const llvm::op
   for (const auto &HCCPath: HCCPathCandidates) {
     if (HCCPath.empty() ||
         !(FS.exists(HCCPath + "/include/hc.hpp") || FS.exists(HCCPath + "/include/hcc/hc.hpp")) || 
-        !FS.exists(HCCPath + "/lib/libmcwamp.a"))
+        !FS.exists(HCCPath + "/lib/libmcwamp.so"))
       continue;
 
     IncPath = HCCPath;


### PR DESCRIPTION
- This option enables GPU code generation at the compile step (rather than during linking)
- The resulting objects could be linked with the system host linker instead of hcc's linker
- This also changes the embedding of GPU IR into the .kernel_ir ELF section since .kernel ELF section is exclusively reserved for GPU ISA. 