### PR TITLE
[clang_tot_upgrade]Add another overload resolution step when dealing with `__global__`s.

### DIFF
--- a/lib/CodeGen/CGCall.cpp
+++ b/lib/CodeGen/CGCall.cpp
@@ -1268,8 +1268,10 @@ static llvm::Value *CreateCoercedLoad(Address Src, llvm::Type *Ty,
 
   // Otherwise do coercion through memory. This is stupid, but simple.
   Address Tmp = CreateTempAllocaForCoercion(CGF, Ty, Src.getAlignment());
-  Address Casted = CGF.Builder.CreateElementBitCast(Tmp,CGF.Int8Ty);
-  Address SrcCasted = CGF.Builder.CreateElementBitCast(Src,CGF.Int8Ty);
+  Address Casted =
+    CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(Tmp, CGF.AllocaInt8PtrTy);
+  Address SrcCasted =
+    CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(Src, CGF.AllocaInt8PtrTy);
   CGF.Builder.CreateMemCpy(Casted, SrcCasted,
       llvm::ConstantInt::get(CGF.IntPtrTy, SrcSize),
       false);
@@ -1350,8 +1352,10 @@ static void CreateCoercedStore(llvm::Value *Src,
     // to that information.
     Address Tmp = CreateTempAllocaForCoercion(CGF, SrcTy, Dst.getAlignment());
     CGF.Builder.CreateStore(Src, Tmp);
-    Address Casted = CGF.Builder.CreateElementBitCast(Tmp,CGF.Int8Ty);
-    Address DstCasted = CGF.Builder.CreateElementBitCast(Dst,CGF.Int8Ty);
+    Address Casted =
+      CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(Tmp, CGF.AllocaInt8PtrTy);
+    Address DstCasted =
+      CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(Dst, CGF.AllocaInt8PtrTy);
     CGF.Builder.CreateMemCpy(DstCasted, Casted,
         llvm::ConstantInt::get(CGF.IntPtrTy, DstSize),
         false);

--- a/lib/Sema/SemaTemplateInstantiateDecl.cpp
+++ b/lib/Sema/SemaTemplateInstantiateDecl.cpp
@@ -1587,9 +1587,11 @@ static QualType adjustFunctionTypeForInstantiation(ASTContext &Context,
 static void MarkByValueRecordsPassedToHIPGlobalFN(FunctionDecl *FDecl)
 { // TODO: this is a temporary kludge; a preferable solution shall be provided
   //       in the future, which shall eschew FE involvement.
+  static constexpr const char HIPLaunch[]{"hipLaunchKernelGGL"};
+
   if (!FDecl) return;
   if (FDecl->getDeclName().isIdentifier() &&
-    FDecl->getName() != "hipLaunchKernelGGL") return;
+    FDecl->getNameAsString().find(HIPLaunch) == std::string::npos) return;
 
   for (auto &&Parameter : FDecl->parameters()) {
     if (Parameter->getOriginalType()->isPointerType()) continue;


### PR DESCRIPTION
This PR adapts https://github.com/RadeonOpenCompute/hcc-clang-upgrade/pull/161 to TIP of clang