### PR TITLE
[hcc] Skip enclosing parentheses, if any, from the kernel

### DIFF
--- a/lib/Sema/SemaOverload.cpp
+++ b/lib/Sema/SemaOverload.cpp
@@ -12432,12 +12432,19 @@ static void maybeCastArgsForHIPGlobalFunction(Sema &S,
   if (ULE->getName().getAsString().find(HIPLaunch) == std::string::npos) {
     return;
   }
-  if (!isa<UnresolvedLookupExpr>(*Args.begin())) return;
+
+  auto F = Args.front();
+  while (!isa<UnresolvedLookupExpr>(F)) {
+    ParenExpr *PE = dyn_cast<ParenExpr>(F);
+    if (!PE)
+      return;
+    F = PE->getSubExpr();
+  }
 
   static constexpr unsigned int IgnoreCnt{5u}; // Skip launch configuration.
 
   FunctionDecl *FD =
-    getBestCandidateForHIP(S, cast<UnresolvedLookupExpr>(*Args.begin()),
+    getBestCandidateForHIP(S, cast<UnresolvedLookupExpr>(F),
                            MultiExprArg{Args.begin() + IgnoreCnt, Args.end()});
 
   if (!FD) return;


### PR DESCRIPTION
The change is to fix the following issue found adding extra parentheses, e.g.

- hipLaunchKernelGGL( MaxUnpoolForward ,  dim3(GET_BLOCKS(count)), dim3(CUDA_NUM_THREADS), 0, THCState_getCurrentStream(state) , 
+ hipLaunchKernelGGL(( MaxUnpoolForward ),  dim3(GET_BLOCKS(count)), dim3(CUDA_NUM_THREADS), 0, THCState_getCurrentStream(state) ,

there would be a better and throughout solution, but it's quick fix