### PR TITLE
Fix AMDGPU Function Calls Flag

### DIFF
--- a/include/clang/Driver/Options.td
+++ b/include/clang/Driver/Options.td
@@ -511,8 +511,9 @@ def hcc_path_EQ : Joined<["--"], "hcc-path=">, Group<i_Group>,
   HelpText<"HCC installation path">;
 def hcc_extra_libs_EQ : Joined<["-", "--"], "hcc-extra-libs=">, Flags<[DriverOption]>,
   HelpText<"Specify hcc extra libraries to be linked in.">;
-def amdgpu_function_calls : Flag<["-"], "amdgpu-function-calls">, Flags<[DriverOption]>,
-  HelpText<"Enable AMD GPU Function Call Support">;
+def famdgpu_function_calls : Flag<["-"], "famdgpu-function-calls">, Flags<[CC1Option]>,
+  HelpText<"Enable AMDGPU Function Call Support">;
+def fno_amdgpu_function_calls : Flag<["-"], "fno-amdgpu-function-calls">;
 def cfguard : Flag<["-"], "cfguard">, Flags<[CC1Option]>,
   HelpText<"Emit tables required for Windows Control Flow Guard.">;
 def cl_opt_disable : Flag<["-"], "cl-opt-disable">, Group<opencl_Group>, Flags<[CC1Option]>,

--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -3502,6 +3502,12 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-fno-common");
     //CmdArgs.push_back("-m32"); // added below using -triple
     CmdArgs.push_back("-O2");
+
+    if (Args.hasFlag(options::OPT_famdgpu_function_calls,
+                     options::OPT_fno_amdgpu_function_calls,
+                     FunctionCallDefault))
+      CmdArgs.push_back("-famdgpu-function-calls");
+
   } else if (JA.ContainsActions(Action::BackendJobClass, types::TY_PP_CXX_AMP_CPU) ||
              JA.ContainsActions(Action::PreprocessJobClass, types::TY_CXX_AMP_CPU)) {
     // path to compile kernel codes on CPU

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -27,6 +27,8 @@ using namespace clang::driver::toolchains;
 using namespace clang::driver::tools;
 using namespace llvm::opt;
 
+bool FunctionCallDefault = false;
+
 HCCInstallationDetector::HCCInstallationDetector(const Driver &D, const llvm::opt::ArgList &Args) : D(D) {
   std::string BinPath = D.Dir;
   std::string InstallPath = D.InstalledDir;
@@ -59,6 +61,11 @@ void HCCInstallationDetector::AddHCCIncludeArgs(const llvm::opt::ArgList &Driver
   if (IsValid) {
     CC1Args.push_back(DriverArgs.MakeArgString("-I" + IncPath + "/include"));
     CC1Args.push_back(DriverArgs.MakeArgString("-I" + IncPath + "/hcc/include"));
+
+    if (DriverArgs.hasFlag(options::OPT_famdgpu_function_calls,
+                           options::OPT_fno_amdgpu_function_calls,
+                           FunctionCallDefault))
+      CC1Args.push_back("-famdgpu-function-calls");
   }
 }
 
@@ -91,8 +98,11 @@ void HCCInstallationDetector::AddHCCLibArgs(const llvm::opt::ArgList &Args, llvm
         CmdArgs.push_back(Args.MakeArgString(prefix + Lib));
     }
 
-    if (Args.hasArg(options::OPT_amdgpu_function_calls))
+    if (Args.hasFlag(options::OPT_famdgpu_function_calls,
+                     options::OPT_fno_amdgpu_function_calls,
+                     FunctionCallDefault)) {
       CmdArgs.push_back("--amdgpu-func-calls");
+    }
   }
 }
 

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -364,12 +364,6 @@ void HCCToolChain::addClangTargetOptions(
   HostTC.addClangTargetOptions(DriverArgs, CC1Args, DeviceOffloadKind);
 
   // TBD, depends on mode set correct arguments
-
-  if (DriverArgs.hasFlag(options::OPT_famdgpu_function_calls,
-                         options::OPT_fno_amdgpu_function_calls,
-                         FunctionCallDefault))
-    CC1Args.push_back("-famdgpu-function-calls");
-
 }
 
 void HCCToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs, ArgStringList &CC1Args) const {

--- a/lib/Driver/ToolChains/Hcc.cpp
+++ b/lib/Driver/ToolChains/Hcc.cpp
@@ -61,11 +61,6 @@ void HCCInstallationDetector::AddHCCIncludeArgs(const llvm::opt::ArgList &Driver
   if (IsValid) {
     CC1Args.push_back(DriverArgs.MakeArgString("-I" + IncPath + "/include"));
     CC1Args.push_back(DriverArgs.MakeArgString("-I" + IncPath + "/hcc/include"));
-
-    if (DriverArgs.hasFlag(options::OPT_famdgpu_function_calls,
-                           options::OPT_fno_amdgpu_function_calls,
-                           FunctionCallDefault))
-      CC1Args.push_back("-famdgpu-function-calls");
   }
 }
 
@@ -96,12 +91,6 @@ void HCCInstallationDetector::AddHCCLibArgs(const llvm::opt::ArgList &Args, llvm
 
       for(auto&& Lib:HccExtraLibs)
         CmdArgs.push_back(Args.MakeArgString(prefix + Lib));
-    }
-
-    if (Args.hasFlag(options::OPT_famdgpu_function_calls,
-                     options::OPT_fno_amdgpu_function_calls,
-                     FunctionCallDefault)) {
-      CmdArgs.push_back("--amdgpu-func-calls");
     }
   }
 }
@@ -280,6 +269,12 @@ namespace
         for (auto&& AMDGPUTarget : AMDGPUTargetVector) {
             validate_and_add_to_command(AMDGPUTarget, C, Args, CmdArgs);
         }
+
+        if (Args.hasFlag(options::OPT_famdgpu_function_calls,
+                         options::OPT_fno_amdgpu_function_calls,
+                         FunctionCallDefault)) {
+          CmdArgs.push_back("--amdgpu-func-calls");
+        }
     }
 }
 
@@ -369,6 +364,12 @@ void HCCToolChain::addClangTargetOptions(
   HostTC.addClangTargetOptions(DriverArgs, CC1Args, DeviceOffloadKind);
 
   // TBD, depends on mode set correct arguments
+
+  if (DriverArgs.hasFlag(options::OPT_famdgpu_function_calls,
+                         options::OPT_fno_amdgpu_function_calls,
+                         FunctionCallDefault))
+    CC1Args.push_back("-famdgpu-function-calls");
+
 }
 
 void HCCToolChain::AddClangSystemIncludeArgs(const ArgList &DriverArgs, ArgStringList &CC1Args) const {

--- a/lib/Driver/ToolChains/Hcc.h
+++ b/lib/Driver/ToolChains/Hcc.h
@@ -15,6 +15,8 @@
 #include "clang/Driver/Tool.h"
 #include "llvm/Support/Compiler.h"
 
+extern bool FunctionCallDefault;
+
 namespace clang {
 namespace driver {
 

--- a/lib/Frontend/CompilerInvocation.cpp
+++ b/lib/Frontend/CompilerInvocation.cpp
@@ -2379,7 +2379,7 @@ static void ParseLangArgs(LangOptions &Opts, ArgList &Args, InputKind IK,
     Opts.NativeHalfArgsAndReturns = 1;
   }
 
-  Opts.AMDGPUFunctionCalls = Args.hasArg(OPT_amdgpu_function_calls);
+  Opts.AMDGPUFunctionCalls = Args.hasArg(OPT_famdgpu_function_calls);
 
   // -cl-strict-aliasing needs to emit diagnostic in the case where CL > 1.0.
   // This option should be deprecated for CL > 1.0 because


### PR DESCRIPTION
Properly pass the flag into CompilerInvocation which needs explicit DriverArgs to CC1Args passing. This allows us to properly set up LangOpt AMDGPUFunctionCalls. Also change amdgpu-function-calls to a flag, -f[no-]amdgpu-function-calls . Let's set the default to false.