### PR TITLE
Fix FCS HCC Unit tests failures

### DIFF
--- a/include/clang/Basic/LangOptions.h
+++ b/include/clang/Basic/LangOptions.h
@@ -295,7 +295,7 @@ public:
   }
 
   bool assumeFunctionsAreConvergent() const {
-    return (CUDA && CUDAIsDevice) || OpenCL;
+    return (CUDA && CUDAIsDevice) || (CPlusPlusAMP && DevicePath) || OpenCL;
   }
 
   /// Return the OpenCL C or C++ version as a VersionTuple.

--- a/lib/CodeGen/CodeGenModule.cpp
+++ b/lib/CodeGen/CodeGenModule.cpp
@@ -1608,10 +1608,6 @@ void CodeGenModule::SetFunctionAttributes(GlobalDecl GD, llvm::Function *F,
   // Set C++AMP kernels carry AMDGPU_KERNEL calling convention
   if (getLangOpts().OpenCL ||
       (getLangOpts().CPlusPlusAMP && CodeGenOpts.AMPIsDevice)) {
-      if (F->getName()=="amp_barrier") {
-          F->addFnAttr(llvm::Attribute::NoDuplicate);
-          F->addFnAttr(llvm::Attribute::NoUnwind);
-      }
       if (FD->hasAttr<OpenCLKernelAttr>())
           F->setCallingConv(llvm::CallingConv::AMDGPU_KERNEL);
   }


### PR DESCRIPTION
This fixes many of the HCC Unit tests with FCS enabled. From 154 failures to 5 failures.