### PR TITLE
allow -g on the device path

### DIFF
--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -3227,8 +3227,6 @@ static void RenderDebugOptions(const ToolChain &TC, const Driver &D,
     }
   }
 
-  if (!IsHCCKernelPath ||
-       DebugInfoKind == codegenoptions::DebugLineTablesOnly) {
   // If a debugger tuning argument appeared, remember it.
   if (const Arg *A =
           Args.getLastArg(options::OPT_gTune_Group, options::OPT_ggdbN_Group)) {
@@ -3419,8 +3417,6 @@ static void RenderDebugOptions(const ToolChain &TC, const Driver &D,
   // scope?
   if (DebuggerTuning == llvm::DebuggerKind::SCE)
     CmdArgs.push_back("-dwarf-explicit-import");
-
-  } // if (!IsHCCKernelPath)
 
   RenderDebugInfoCompressionArgs(Args, CmdArgs, D, TC);
 }


### PR DESCRIPTION
-g was disabled on the device path in the past for various technical reasons but we want to re-enable it for rocm gdb