### PR TITLE
Revert "allow -g on the device path"

### DIFF
--- a/lib/Driver/ToolChains/Clang.cpp
+++ b/lib/Driver/ToolChains/Clang.cpp
@@ -3217,6 +3217,8 @@ static void RenderDebugOptions(const ToolChain &TC, const Driver &D,
     }
   }
 
+  if (!IsHCCKernelPath ||
+       DebugInfoKind == codegenoptions::DebugLineTablesOnly) {
   // If a debugger tuning argument appeared, remember it.
   if (const Arg *A =
           Args.getLastArg(options::OPT_gTune_Group, options::OPT_ggdbN_Group)) {
@@ -3397,6 +3399,8 @@ static void RenderDebugOptions(const ToolChain &TC, const Driver &D,
   // scope?
   if (DebuggerTuning == llvm::DebuggerKind::SCE)
     CmdArgs.push_back("-dwarf-explicit-import");
+
+  } // if (!IsHCCKernelPath)
 
   RenderDebugInfoCompressionArgs(Args, CmdArgs, D, TC);
 }


### PR DESCRIPTION
Reverts RadeonOpenCompute/hcc-clang-upgrade#178
This is causing some regression for kernels that contain variables in LDS memory