### PR TITLE
Hide the hcc-specific macros being CPlusPlusAmp.

### DIFF
--- a/lib/Frontend/InitPreprocessor.cpp
+++ b/lib/Frontend/InitPreprocessor.cpp
@@ -576,8 +576,10 @@ static void InitializePredefinedMacros(const TargetInfo &TI,
   Builder.defineMacro("__clang__"); // Clang Frontend
 
   // hcc macros
-  Builder.defineMacro("__KALMAR_CC__", "1");
-  Builder.defineMacro("__HCC__", "1");
+  if (LangOpts.CPlusPlusAMP) {
+    Builder.defineMacro("__KALMAR_CC__", "1");
+    Builder.defineMacro("__HCC__", "1");
+  }
 
 #define TOSTR2(X) #X
 #define TOSTR(X) TOSTR2(X)


### PR DESCRIPTION
We are trying to make hcc's clang++ useful as a host compiler.

With `__HCC__=1` unconditionally, header guards in HIP that use this to differentiate between host/device compiler become enabled even if `clang++` is intended to be used as a host compiler.